### PR TITLE
Update -> continue on error, write all errors to separate file.

### DIFF
--- a/lib/product-discount-import.coffee
+++ b/lib/product-discount-import.coffee
@@ -9,7 +9,7 @@ slugify = require 'underscore.string/slugify'
 class ProductDiscountImport
 
   constructor: (@logger, options = {}) ->
-    @client = new SphereClient options
+    @client = new SphereClient options.config
     @language = 'en'
     @_resetSummary()
 

--- a/lib/product-discount-import.coffee
+++ b/lib/product-discount-import.coffee
@@ -9,7 +9,7 @@ slugify = require 'underscore.string/slugify'
 class ProductDiscountImport
 
   constructor: (@logger, options = {}) ->
-    @client = new SphereClient options.config
+    @client = new SphereClient options.clientConfig
     @language = 'en'
     @_resetSummary()
 

--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -79,8 +79,9 @@ class ProductImport
             @_summary.failed++
             if @_summary.failed < @errorLimit or @errorLimit is 0
               @logger.error "Skipping product due to error: #{r.reason().message}"
-              errorFile = path.join(@errorDir, "error-#{@_summary.failed}.json")
-              fs.outputJsonSync(errorFile, r.reason(), {spaces: 2})
+              if @errorDir
+                errorFile = path.join(@errorDir, "error-#{@_summary.failed}.json")
+                fs.outputJsonSync(errorFile, r.reason(), {spaces: 2})
             else
               @logger.warn "Error not logged as error limit of #{@errorLimit} has reached."
         Promise.resolve(@_summary)

--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -12,7 +12,7 @@ class ProductImport
   constructor: (@logger, options = {}) ->
     @sync = new ProductSync
     @sync.config [{type: 'prices', group: 'black'}].concat(['base', 'references', 'attributes', 'images', 'variants', 'metaAttributes'].map (type) -> {type, group: 'white'})
-    @client = new SphereClient options.config
+    @client = new SphereClient options.clientConfig
     @errorDir = options.errorDir
     @errorLimit = options.errorLimit
     @_resetCache()

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "sphere-node-sdk": "1.4.2",
     "sphere-node-utils": "0.7.0",
     "underscore": "1.8.3",
-    "underscore.string": "3.1.1"
+    "underscore.string": "3.1.1",
+    "fs-extra": "0.22.1"
   },
   "devDependencies": {
     "grunt-cli": "0.1.13",

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -159,4 +159,16 @@ describe 'Product import integration tests', ->
       .catch (err) -> done(_.prettify err.body)
     , 10000
 
+    it ' :: should continue on error', (done) ->
+      sampleImport = _.deepClone sampleImportJson
+      sampleImport.products[1].slug.en = 'product-sync-test-product-1'
+      @import._processBatches(sampleImport.products)
+      .then =>
+        expect(@import._summary.failed).toBe 1
+        expect(@import._summary.created).toBe 1
+        done()
+      .catch (err) ->
+        done(err)
+
+
 

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -54,7 +54,7 @@ describe 'Product import integration tests', ->
     fs.emptyDirSync(errorDir)
 
     Config =
-      config: ClientConfig
+      clientConfig: ClientConfig
       errorDir: errorDir
       errorLimit: 30
 

--- a/test/integration/price-import.spec.coffee
+++ b/test/integration/price-import.spec.coffee
@@ -61,7 +61,7 @@ describe 'Price Importer integration tests', ->
         ]
 
     Config =
-      config: ClientConfig
+      clientConfig: ClientConfig
       errorDir: 'somedir'
       errorLimit: 0
 

--- a/test/integration/price-import.spec.coffee
+++ b/test/integration/price-import.spec.coffee
@@ -2,7 +2,7 @@ debug = require('debug')('spec:it:sphere-product-import')
 _ = require 'underscore'
 _.mixin require 'underscore-mixins'
 {PriceImport} = require '../../lib'
-Config = require '../../config'
+ClientConfig = require '../../config'
 Promise = require 'bluebird'
 {ExtendedLogger} = require 'sphere-node-utils'
 package_json = require '../../package.json'
@@ -53,12 +53,17 @@ describe 'Price Importer integration tests', ->
   beforeEach (done) ->
     @logger = new ExtendedLogger
       additionalFields:
-        project_key: Config.config.project_key
+        project_key: ClientConfig.config.project_key
       logConfig:
         name: "#{package_json.name}-#{package_json.version}"
         streams: [
           { level: 'info', stream: process.stdout }
         ]
+
+    Config =
+      config: ClientConfig
+      errorDir: 'somedir'
+      errorLimit: 0
 
     @import = new PriceImport @logger, Config
 

--- a/test/integration/product-discount-import.spec.coffee
+++ b/test/integration/product-discount-import.spec.coffee
@@ -2,7 +2,7 @@ debug = require('debug')('spec:it:sphere-product-discount-import')
 _ = require 'underscore'
 _.mixin require 'underscore-mixins'
 {ProductDiscountImport} = require '../../lib'
-Config = require '../../config'
+ClientConfig = require '../../config'
 Promise = require 'bluebird'
 {ExtendedLogger} = require 'sphere-node-utils'
 package_json = require '../../package.json'
@@ -22,12 +22,17 @@ describe 'Product Discount Importer integration tests', ->
   beforeEach (done) ->
     @logger = new ExtendedLogger
       additionalFields:
-        project_key: Config.config.project_key
+        project_key: ClientConfig.config.project_key
       logConfig:
         name: "#{package_json.name}-#{package_json.version}"
         streams: [
           { level: 'info', stream: process.stdout }
         ]
+
+    Config =
+      config: ClientConfig
+      errorDir: 'somedir'
+      errorLimit: 0
 
     @import = new ProductDiscountImport @logger, Config
 

--- a/test/integration/product-discount-import.spec.coffee
+++ b/test/integration/product-discount-import.spec.coffee
@@ -30,7 +30,7 @@ describe 'Product Discount Importer integration tests', ->
         ]
 
     Config =
-      config: ClientConfig
+      clientConfig: ClientConfig
       errorDir: 'somedir'
       errorLimit: 0
 

--- a/test/price-import.spec.coffee
+++ b/test/price-import.spec.coffee
@@ -1,12 +1,18 @@
 _ = require 'underscore'
 _.mixin require 'underscore-mixins'
 {PriceImport} = require '../lib'
-Config = require '../config'
+ClientConfig = require '../config'
 Promise = require 'bluebird'
 
 describe 'PriceImport', ->
 
   beforeEach ->
+
+    Config =
+      config: ClientConfig
+      errorDir: 'somedir'
+      errorLimit: 0
+
     @import = new PriceImport null, Config
 
   it 'should initialize', ->

--- a/test/price-import.spec.coffee
+++ b/test/price-import.spec.coffee
@@ -9,7 +9,7 @@ describe 'PriceImport', ->
   beforeEach ->
 
     Config =
-      config: ClientConfig
+      clientConfig: ClientConfig
       errorDir: 'somedir'
       errorLimit: 0
 

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -160,7 +160,7 @@ describe 'ProductImport unit tests', ->
     errorDir = path.join(__dirname, '../errors')
 
     Config =
-      config: ClientConfig
+      clientConfig: ClientConfig
       errorDir: errorDir
       errorLimit: 0
 

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -3,6 +3,7 @@ _.mixin require 'underscore-mixins'
 {ProductImport} = require '../lib'
 Config = require '../config'
 Promise = require 'bluebird'
+path = require 'path'
 
 frozenTimeStamp = new Date().getTime()
 
@@ -152,7 +153,7 @@ sampleReferenceCats =
     id: 'category_external_id2'
   ]
 
-describe 'ProductImport', ->
+describe 'ProductImport unit tests', ->
 
   beforeEach ->
     @import = new ProductImport null, Config
@@ -442,7 +443,7 @@ describe 'ProductImport', ->
       spyOn(@import, "_extractUniqueSkus").andCallThrough()
       spyOn(@import, "_createProductFetchBySkuQueryPredicate").andCallThrough()
       spyOn(@import.client.productProjections,"fetch").andCallFake -> Promise.resolve({body: {results: existingProducts}})
-      spyOn(@import, "_createOrUpdate").andCallFake -> Promise.all([Promise.resolve({statusCode: 201}), Promise.resolve({statusCode: 200})])
+      spyOn(@import, "_createOrUpdate").andCallFake -> Promise.settle([Promise.resolve({statusCode: 201}), Promise.resolve({statusCode: 200})])
       @import._processBatches(sampleProducts)
       .then =>
         expect(@import._extractUniqueSkus).toHaveBeenCalled()
@@ -451,6 +452,8 @@ describe 'ProductImport', ->
           emptySKU: 2
           created: 1
           updated: 1
+          failed: 0
+          errorDir: path.join(__dirname,'../errors')
         done()
       .catch done
 

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -1,7 +1,7 @@
 _ = require 'underscore'
 _.mixin require 'underscore-mixins'
 {ProductImport} = require '../lib'
-Config = require '../config'
+ClientConfig = require '../config'
 Promise = require 'bluebird'
 path = require 'path'
 
@@ -156,6 +156,14 @@ sampleReferenceCats =
 describe 'ProductImport unit tests', ->
 
   beforeEach ->
+
+    errorDir = path.join(__dirname, '../errors')
+
+    Config =
+      config: ClientConfig
+      errorDir: errorDir
+      errorLimit: 0
+
     @import = new ProductImport null, Config
 
   it 'should initialize', ->


### PR DESCRIPTION
* does not stop process on error
* skips the products with errors
* logs the error message
* writes the complete error message with the original request to a file in the {current directory}/errors/error-x.json