### PR TITLE
Same for all attribute update

### DIFF
--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -148,6 +148,18 @@ class ProductImport
     debug 'About to send %s requests', _.size(posts)
     Promise.settle(posts)
 
+  _fetchSameForAllAttributesOfProductType: (productType) =>
+    new Promise (resolve) =>
+      if @_cache.productType["#{productType.id}_sameForAllAttributes"]
+        resolve(@_cache.productType["#{productType.id}_sameForAllAttributes"])
+      else
+        @_resolveReference(@client.productTypes, 'productType', productType, "name=\"#{productType?.id}\"")
+        .then (productTypeId) =>
+          sameValueAttributes = _.where(@_cache.productType[productTypeId].attributes, {attributeConstraint: "SameForAll"})
+          sameValueAttributeNames = _.pluck(sameValueAttributes, 'name')
+          @_cache.productType["#{productType.id}_sameForAllAttributes"] = sameValueAttributeNames
+          resolve(sameValueAttributeNames)
+
   _ensureVariantDefaults: (variant = {}) ->
     variantDefaults =
       attributes: []

--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -293,7 +293,7 @@ class ProductImport
       if not @_cache[refKey]
         @_cache[refKey] = {}
       if @_cache[refKey][ref.id]
-        resolve(@_cache[refKey][ref.id])
+        resolve(@_cache[refKey][ref.id].id)
       else
         request = service.where(predicate)
         if refKey is 'product'
@@ -305,7 +305,7 @@ class ProductImport
           else
             if _.size(result.body.results) > 1
               @logger.warn "Found more than 1 #{refKey} for #{ref.id}"
-            @_cache[refKey][ref.id] = result.body.results[0].id
+            @_cache[refKey][ref.id] = result.body.results[0]
             resolve(result.body.results[0].id)
 
 module.exports = ProductImport

--- a/samples/sample-product-type.json
+++ b/samples/sample-product-type.json
@@ -12,7 +12,21 @@
         {
           "en": "Product Id"
         },
-      "isRequired": false
+      "isRequired": false,
+      "attributeConstraint": "None"
+    },
+    {
+      "name": "sample_attribute_1",
+      "type":
+      {
+        "name": "text"
+      },
+      "label":
+      {
+        "en": "Sample Attribute 1"
+      },
+      "isRequired": false,
+      "attributeConstraint": "SameForAll"
     }
   ]
 }

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -6,6 +6,7 @@ ClientConfig = require '../config'
 Promise = require 'bluebird'
 path = require 'path'
 fs = require 'fs-extra'
+jasmine = require 'jasmine-node'
 {ExtendedLogger} = require 'sphere-node-utils'
 package_json = require '../package.json'
 sampleImportJson = require '../samples/import.json'
@@ -153,6 +154,7 @@ describe 'Product import integration tests', ->
         country: 'JP'
       sampleImport.products[0].variants[0].prices = [samplePrice]
 
+      spyOn(@import.sync, 'buildActions').andCallThrough()
       @import._processBatches(sampleUpdate.products)
       .then =>
         expect(@import._summary.created).toBe 1
@@ -162,6 +164,7 @@ describe 'Product import integration tests', ->
       .then =>
         expect(@import._summary.created).toBe 1
         expect(@import._summary.updated).toBe 1
+        expect(@import.sync.buildActions).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(Object), ['sample_attribute_1'])
         predicate = "masterVariant(sku=\"#{sampleUpdate.products[0].masterVariant.sku}\")"
         @client.productProjections.where(predicate).staged(true).fetch()
       .then (result) ->

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -429,7 +429,8 @@ describe 'ProductImport unit tests', ->
         version: 1
 
       spyOn(@import, "_prepareNewProduct").andCallFake (prepareProduct) -> Promise.resolve(prepareProduct)
-      spyOn(@import,"_prepareUpdateProduct").andCallFake (prepareProduct) -> Promise.resolve(prepareProduct)
+      spyOn(@import, "_prepareUpdateProduct").andCallFake (prepareProduct) -> Promise.resolve(prepareProduct)
+      spyOn(@import, "_fetchSameForAllAttributesOfProductType").andCallFake -> Promise.resolve([])
       spyOn(@import.client._rest, 'POST').andCallFake (endpoint, payload, callback) ->
         callback(null, {statusCode: 200}, {})
       @import._createOrUpdate([newProduct,updateProduct],existingProducts)

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -611,7 +611,45 @@ describe 'ProductImport unit tests', ->
       .catch (err) ->
         done(err)
 
+  describe 'same for all attribute type', ->
 
+    it ' :: should return a list of names with same for all attribute type and cache the response', (done) ->
+
+      sampleProductType = _.deepClone(sampleProductTypeResponse)
+
+      attribute =
+        name: 'sample attribute'
+        label:
+          en: 'sample attribute 1 label'
+        isRequired: true
+        type:
+          name: 'text'
+        attributeConstraint: 'SameForAll'
+        isSearchable: true
+
+      attribute1 = _.deepClone(attribute)
+      attribute1.name = 'sample attribute 1'
+
+      attribute2 = _.deepClone(attribute)
+      attribute2.name = 'sample attribute 2'
+      attribute2.attributeConstraint = 'None'
+
+      attribute3 = _.deepClone(attribute)
+      attribute3.name = 'sample attribute 3'
+
+      sampleProductType.body.results[0].attributes = [attribute1, attribute2, attribute3]
+
+      productType =
+        id: 'AGS'
+
+      spyOn(@import.client.productTypes, "fetch").andCallFake -> Promise.resolve(sampleProductType)
+      @import._fetchSameForAllAttributesOfProductType(productType)
+      .then (result) =>
+        expect(result).toEqual ['sample attribute 1', 'sample attribute 3']
+        expect(@import._cache.productType["#{productType.id}_sameForAllAttributes"]).toEqual ['sample attribute 1', 'sample attribute 3']
+        done()
+      .catch (err) ->
+        done(err)
 
 
 

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -215,7 +215,7 @@ describe 'ProductImport unit tests', ->
       .then (result) =>
         expect(@import.client.productTypes.fetch).toHaveBeenCalled()
         expect(result).toEqual sampleProductTypeResponse.body.results[0].id
-        expect(@import._cache.productType["AGS"]).toEqual sampleProductTypeResponse.body.results[0].id
+        expect(@import._cache.productType["AGS"].id).toEqual sampleProductTypeResponse.body.results[0].id
         done()
       .catch done
 
@@ -227,7 +227,7 @@ describe 'ProductImport unit tests', ->
       .then (result) =>
         expect(@import.client.taxCategories.fetch).toHaveBeenCalled()
         expect(result).toEqual sampleTaxCategoryResponse.body.results[0].id
-        expect(@import._cache.taxCategory["defaultTax_AT"]).toEqual sampleTaxCategoryResponse.body.results[0].id
+        expect(@import._cache.taxCategory["defaultTax_AT"].id).toEqual sampleTaxCategoryResponse.body.results[0].id
         done()
       .catch done
 
@@ -240,14 +240,14 @@ describe 'ProductImport unit tests', ->
       .then (result) =>
         expect(@import.client.categories.fetch).toHaveBeenCalled()
         expect(result).toEqual sampleCategoriesResponse.body.results[0].id
-        expect(@import._cache.categories["category_external_id1"]).toEqual sampleCategoriesResponse.body.results[0].id
+        expect(@import._cache.categories["category_external_id1"].id).toEqual sampleCategoriesResponse.body.results[0].id
         done()
       .catch done
 
 
     it 'should resolve reference from cache', (done) ->
       @import._resetCache()
-      @import._cache.taxCategory['defaultTax_AT'] = "tax_category_internal_id"
+      @import._cache.taxCategory['defaultTax_AT'] = {"id": "tax_category_internal_id"}
       spyOn(@import.client.taxCategories, "fetch").andCallFake -> Promise.resolve(sampleTaxCategoryResponse)
       taxCategoryRef = { id: 'defaultTax_AT' }
       @import._resolveReference(@import.client.taxCategories, 'taxCategory', taxCategoryRef, "name=\"#{taxCategoryRef.id}\"")


### PR DESCRIPTION
For every product extracts attribute names of type sameForAll from the product type and passes the names as an argument to the build action method of sync module. 