### PR TITLE
Product Sync whitelist and blacklist configurable

### DIFF
--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -11,7 +11,7 @@ class ProductImport
 
   constructor: (@logger, options = {}) ->
     @sync = new ProductSync
-    if options.blackList
+    if options.blackList and ProductSync.actions
       @sync.config @_configureSync(options.blackList)
     @client = new SphereClient options.clientConfig
     @_configErrorHandling(options)

--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -11,12 +11,25 @@ class ProductImport
 
   constructor: (@logger, options = {}) ->
     @sync = new ProductSync
-    @sync.config [{type: 'prices', group: 'black'}].concat(['base', 'references', 'attributes', 'images', 'variants', 'metaAttributes'].map (type) -> {type, group: 'white'})
+    if options.blackList
+      @sync.config @_configureSync(options.blackList)
     @client = new SphereClient options.clientConfig
     @_configErrorHandling(options)
     @_resetCache()
     @_resetSummary()
-    if @logger then @logger.info "Product Importer initialized with config -> errorDir: #{@errorDir}, errorLimit: #{@errorLimit}"
+    if @logger then @logger.info "Product Importer initialized with config -> errorDir: #{@errorDir}, errorLimit: #{@errorLimit}, blacklist actions: #{options.blackList}"
+
+  _configureSync: (blackList) =>
+    @_validateSyncConfig(blackList)
+    debug "Product sync config validated"
+    _.difference(ProductSync.actions, blackList)
+      .map (type) -> {type: type, group: 'white'}
+      .concat(blackList.map (type) -> {type: type, group: 'black'})
+
+  _validateSyncConfig: (blackList) ->
+    for actionGroup in blackList
+      if not _.contains(ProductSync.actions, actionGroup)
+        throw ("invalid product sync action group: #{actionGroup}")
 
   _configErrorHandling: (options) =>
     if options.errorDir

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "bluebird": "2.9.33",
     "debug": "2.2.0",
-    "sphere-node-sdk": "1.4.2",
+    "sphere-node-sdk": "1.4.3",
     "sphere-node-utils": "0.7.0",
     "underscore": "1.8.3",
     "underscore.string": "3.1.1",

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -58,6 +58,7 @@ describe 'Product import integration tests', ->
       clientConfig: ClientConfig
       errorDir: errorDir
       errorLimit: 30
+      blackList: ['prices']
 
     @import = new ProductImport @logger, Config
 

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -163,6 +163,7 @@ describe 'ProductImport unit tests', ->
       clientConfig: ClientConfig
       errorDir: errorDir
       errorLimit: 0
+      blackList: ['prices']
 
     @import = new ProductImport null, Config
 


### PR DESCRIPTION
Product Importer can be configured with desired whitelist and blacklist of action groups available for Product Sync.

The following pull request needs to be merged and released before this update will work:  
https://github.com/sphereio/sphere-node-sdk/pull/82