### PR TITLE
Add -> test to check handling of set type attribute values.

### DIFF
--- a/samples/sample-product-type.json
+++ b/samples/sample-product-type.json
@@ -27,6 +27,21 @@
       },
       "isRequired": false,
       "attributeConstraint": "SameForAll"
+    },
+    {
+      "name": "sample_set_text",
+      "label": {
+        "en": "Sample Set Text"
+      },
+      "isRequired": false,
+      "type": {
+        "name": "set",
+        "elementType": {
+          "name": "text"
+        }
+      },
+      "attributeConstraint": "None",
+      "isSearchable": true
     }
   ]
 }

--- a/samples/sample-products.json
+++ b/samples/sample-products.json
@@ -37,6 +37,14 @@
             "_custom": {
               "predicate": "masterVariant(sku=\"attribute_value_to_resolve_by\") or variants(sku=\"attribute_value_to_resolve_by\")"
             }
+          },
+          {
+            "name": "sample_set_text",
+            "value": ["set_text_1"]
+          },
+          {
+            "name": "sample_set_text_2",
+            "value": ["text_1", "text_2", "text_3"]
           }
         ]
       },


### PR DESCRIPTION
input values are handled correclty: 

```javascript
          {
            "name": "sample_set_text",
            "value": ["set_text_1"]
          },
          {
            "name": "sample_set_text_2",
            "value": ["text_1", "text_2", "text_3"]
          }
```