### PR TITLE
Ignore slug updates

### DIFF
--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -268,7 +268,7 @@ class ProductImport
       @_resolveReference(@client.taxCategories, 'taxCategory', productToProcess.taxCategory, "name=\"#{productToProcess.taxCategory?.id}\"")
       @_fetchAndResolveCustomReferences(productToProcess)
     ]
-    .spread (prodCatsIds, taxCatId) ->
+    .spread (prodCatsIds, taxCatId) =>
       if taxCatId
         productToProcess.taxCategory =
           id: taxCatId
@@ -286,6 +286,8 @@ class ProductImport
     else if not productToProcess.slug
       debug 'slug missing in product to process, assigning same as existing product: %s', existingProduct.slug
       slug = existingProduct.slug # to prevent removing slug from existing product.
+    else
+      slug = productToProcess.slug
     slug
 
   _prepareNewProduct: (product) ->

--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -17,6 +17,7 @@ class ProductImport
       @sync.config @_configureSync(options.blackList)
     @ensureEnums = options.ensureEnums or false
     @filterUnknownAttributes = options.filterUnknownAttributes or false
+    @ignoreSlugUpdates = options.ignoreSlugUpdates or false
     @client = new SphereClient options.clientConfig
     @enumValidator = new EnumValidator @logger
     @unknownAttributesFilter = new UnknownAttributesFilter @logger
@@ -276,10 +277,16 @@ class ProductImport
         productToProcess.categories = _.map prodCatsIds, (catId) ->
           id: catId
           typeId: 'category'
-      if not productToProcess.slug
-        debug 'slug missing in product to process, assigning same as existing product: %s', existingProduct.slug
-        productToProcess.slug = existingProduct.slug # to prevent removing slug from existing product.
+      productToProcess.slug = @_updateProductSlug productToProcess, existingProduct
       Promise.resolve productToProcess
+
+  _updateProductSlug: (productToProcess, existingProduct) =>
+    if @ignoreSlugUpdates
+      slug = existingProduct.slug
+    else if not productToProcess.slug
+      debug 'slug missing in product to process, assigning same as existing product: %s', existingProduct.slug
+      slug = existingProduct.slug # to prevent removing slug from existing product.
+    slug
 
   _prepareNewProduct: (product) ->
     product = @_ensureDefaults(product)

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -308,9 +308,9 @@ describe 'ProductImport unit tests', ->
         done()
       .catch done
 
-  xdescribe '::_generateSlug', ->
+  describe '::_generateSlug', ->
 
-    it 'should generate valid slug', ->
+    xit 'should generate valid slug', ->
       sampleName =
         name:
           en: 'sample_product_name'
@@ -320,6 +320,33 @@ describe 'ProductImport unit tests', ->
       slugs = @import._generateSlug(sampleName.name)
       expect(slugs.en).toBe "sample-product-name-#{frozenTimeStamp}"
       expect(slugs.de).toBe "sample-product-german-name-#{frozenTimeStamp}"
+
+    it ' should ignore slug update', ->
+      sampleProduct =
+        slug:
+          en: 'some-new-slug'
+      existingProduct =
+        slug:
+          en: 'existing-slug'
+
+      @import.ignoreSlugUpdates = true
+      newSlug = @import._updateProductSlug(sampleProduct, existingProduct)
+      sampleProduct.slug = newSlug
+      console.log JSON.stringify(sampleProduct, null, 2)
+      expect(@import._updateProductSlug(sampleProduct, existingProduct)).toEqual existingProduct.slug
+
+    it ' should replace empty slug of update product with existing slug', ->
+      sampleProduct =
+        name:
+          en: 'sample product name'
+      existingProduct =
+        name:
+          en: 'sample product name'
+        slug:
+          en: 'sample-product-name'
+
+      @import.ignoreSlugUpdates = false
+      expect(@import._updateProductSlug(sampleProduct,existingProduct)).toEqual existingProduct.slug
 
 
   describe '::_prepareNewProduct', ->

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -332,7 +332,6 @@ describe 'ProductImport unit tests', ->
       @import.ignoreSlugUpdates = true
       newSlug = @import._updateProductSlug(sampleProduct, existingProduct)
       sampleProduct.slug = newSlug
-      console.log JSON.stringify(sampleProduct, null, 2)
       expect(@import._updateProductSlug(sampleProduct, existingProduct)).toEqual existingProduct.slug
 
     it ' should replace empty slug of update product with existing slug', ->

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -310,7 +310,7 @@ describe 'ProductImport unit tests', ->
 
   describe '::_generateSlug', ->
 
-    xit 'should generate valid slug', ->
+    it 'should generate valid slug', ->
       sampleName =
         name:
           en: 'sample_product_name'


### PR DESCRIPTION
Option to ignore slug updates by replacing the slug with the slug of existing product.

reason: https://github.com/sphereio/sphere-product-import/issues/48