### PR TITLE
Ensure enums in product type

### DIFF
--- a/lib/common-utils.coffee
+++ b/lib/common-utils.coffee
@@ -1,0 +1,25 @@
+debug = require('debug')('sphere-product-import-common-utils')
+_ = require 'underscore'
+_.mixin require 'underscore-mixins'
+
+class CommonUtils
+
+  constructor: (@logger) ->
+    debug "Enum Validator initialized."
+
+
+  uniqueObjectFilter: (objCollection) =>
+    uniques = []
+    _.each objCollection, (obj) =>
+      if not @isObjectPresentInArray(uniques, obj) then uniques.push(obj)
+    uniques
+
+
+  isObjectPresentInArray: (array, object) ->
+    present = false
+    _.each array, (element) ->
+      if _.isEqual(object, element)
+        present = true
+    present
+
+module.exports = CommonUtils

--- a/lib/common-utils.coffee
+++ b/lib/common-utils.coffee
@@ -16,10 +16,6 @@ class CommonUtils
 
 
   isObjectPresentInArray: (array, object) ->
-    present = false
-    _.each array, (element) ->
-      if _.isEqual(object, element)
-        present = true
-    present
+    _.find array, (element) -> _.isEqual(element, object)
 
 module.exports = CommonUtils

--- a/lib/enum-validator.coffee
+++ b/lib/enum-validator.coffee
@@ -34,7 +34,7 @@ class EnumValidator
           if not @_isEnumKeyPresent(ea, refEnum)
             updateActions.push @_generateUpdateAction(ea, refEnum)
         else
-          throw err "enum attribute name: #{ea.name} not found in Product Type: #{productType.name}", ea
+          debug "enum attribute name: #{ea.name} not found in Product Type: #{productType.name}"
       else
         debug "Skipping #{ea.name} update action generation as already exists."
     updateActions

--- a/lib/enum-validator.coffee
+++ b/lib/enum-validator.coffee
@@ -29,15 +29,17 @@ class EnumValidator
     referenceEnums = @_fetchEnumAttributesOfProductType(productType)
     for ea in enumAttributes
       if not @_isEnumGenerated(ea)
-        refEnum = _.findWhere(referenceEnums, {name: "#{ea.name}"})
-        if refEnum
-          if not @_isEnumKeyPresent(ea, refEnum)
-            updateActions.push @_generateUpdateAction(ea, refEnum)
-        else
-          debug "enum attribute name: #{ea.name} not found in Product Type: #{productType.name}"
+        @_handleNewEnumAttributeUpdate(ea, referenceEnums, updateActions, productType)
       else
         debug "Skipping #{ea.name} update action generation as already exists."
     updateActions
+
+  _handleNewEnumAttributeUpdate: (ea, referenceEnums, updateActions, productType) =>
+    refEnum = _.findWhere(referenceEnums, {name: "#{ea.name}"})
+    if refEnum and not @_isEnumKeyPresent(ea, refEnum)
+      updateActions.push @_generateUpdateAction(ea, refEnum)
+    else
+      debug "enum attribute name: #{ea.name} not found in Product Type: #{productType.name}"
 
   _isEnumGenerated: (ea) =>
     @_cache.generatedEnums["#{ea.name}-#{slugify(ea.value)}"]

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -5,3 +5,4 @@ module.exports =
   ProductDiscountImport: require './product-discount-import'
   EnumValidator: require './enum-validator'
   UnknownAttributesFilter: require './unknown-attributes-filter'
+  CommonUtils: require './common-utils'

--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -201,12 +201,12 @@ class ProductImport
   #   productTypeId: [{updateAction},{updateAction},...]
   # }
   _filterUniqueUpdateActions: (updateActions) =>
-    uniqueUpdateActions = {}
-    _.each _.keys(updateActions), (productTypeId) =>
+    _.reduce _.keys(updateActions), (acc, productTypeId) =>
       actions = updateActions[productTypeId]
       uniqueActions = @commonUtils.uniqueObjectFilter actions
-      uniqueUpdateActions[productTypeId] = uniqueActions
-    uniqueUpdateActions
+      acc[productTypeId] = uniqueActions
+      acc
+    , {}
 
   _ensureProductTypesInMemory: (products) =>
     Promise.map products, (product) =>

--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -106,6 +106,7 @@ class ProductImport
         @client.productProjections
         .where(predicate)
         .staged(true)
+        .all()
         .fetch()
       .then (results) =>
         debug 'Fetched products: %j', results

--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -106,7 +106,6 @@ class ProductImport
         @client.productProjections
         .where(predicate)
         .staged(true)
-        .all()
         .fetch()
       .then (results) =>
         debug 'Fetched products: %j', results

--- a/samples/sample-product-type.json
+++ b/samples/sample-product-type.json
@@ -42,6 +42,26 @@
       },
       "attributeConstraint": "None",
       "isSearchable": true
+    },
+    {
+      "name": "sample_enum_attribute",
+      "label": {
+        "en": "Sample Enum Attribute"
+      },
+      "isRequired": false,
+      "type": {
+        "name": "enum",
+        "values": [
+          {
+            "key": "enum-1-key",
+            "label": "Enum 1 Label"
+          },
+          {
+            "key": "enum-2-key",
+            "label": "Enum 2 Label"
+          }
+        ]
+      }
     }
   ]
 }

--- a/test/common-utils.spec.coffee
+++ b/test/common-utils.spec.coffee
@@ -53,14 +53,14 @@ describe 'Common Utils unit tests', ->
 
     @import = new CommonUtils @logger
 
-  it ' :: should initialize', ->
+  it ' should initialize', ->
     expect(@import).toBeDefined()
 
-  it ' :: should filter unique objects from collection', ->
+  it ' should filter unique objects from collection', ->
     uniqueCollection = @import.uniqueObjectFilter(sampleObjectCollection)
     expect(uniqueCollection).toEqual expectUniqueCollection
 
-  it ' :: should detect an existing object in an array of objects', ->
+  it ' should detect an existing object in an array of objects', ->
     testObject =
       action: 'addPlainEnumValue'
       attributeName: 'sample-enum-attribute'

--- a/test/common-utils.spec.coffee
+++ b/test/common-utils.spec.coffee
@@ -1,0 +1,71 @@
+debug = require('debug')('spec:common-utils')
+_ = require 'underscore'
+_.mixin require 'underscore-mixins'
+{CommonUtils} = require '../lib'
+{ExtendedLogger} = require 'sphere-node-utils'
+package_json = require '../package.json'
+
+sampleObjectCollection = [
+  action: 'addPlainEnumValue'
+  attributeName: 'sample-enum-attribute'
+  value:
+    key: 'enum-3-key'
+    label: 'enum-3-key'
+,
+  action: 'addPlainEnumValue'
+  attributeName: 'sample-enum-attribute'
+  value:
+    key: 'enum-1-key'
+    label: 'enum-1-key'
+,
+  action: 'addPlainEnumValue'
+  attributeName: 'sample-enum-attribute'
+  value:
+    key: 'enum-3-key'
+    label: 'enum-3-key'
+]
+
+expectUniqueCollection = [
+  action: 'addPlainEnumValue'
+  attributeName: 'sample-enum-attribute'
+  value:
+    key: 'enum-3-key'
+    label: 'enum-3-key'
+,
+  action: 'addPlainEnumValue'
+  attributeName: 'sample-enum-attribute'
+  value:
+    key: 'enum-1-key'
+    label: 'enum-1-key'
+]
+
+describe 'Common Utils unit tests', ->
+
+  beforeEach ->
+    @logger = new ExtendedLogger
+      additionalFields:
+        project_key: 'enumValidator'
+      logConfig:
+        name: "#{package_json.name}-#{package_json.version}"
+        streams: [
+          { level: 'info', stream: process.stdout }
+        ]
+
+    @import = new CommonUtils @logger
+
+  it ' :: should initialize', ->
+    expect(@import).toBeDefined()
+
+  it ' :: should filter unique objects from collection', ->
+    uniqueCollection = @import.uniqueObjectFilter(sampleObjectCollection)
+    expect(uniqueCollection).toEqual expectUniqueCollection
+
+  it ' :: should detect an existing object in an array of objects', ->
+    testObject =
+      action: 'addPlainEnumValue'
+      attributeName: 'sample-enum-attribute'
+      value:
+        key: 'enum-3-key'
+        label: 'enum-3-key'
+
+    expect(@import.isObjectPresentInArray(sampleObjectCollection, testObject)).toBeTruthy()

--- a/test/enum-validator.spec.coffee
+++ b/test/enum-validator.spec.coffee
@@ -292,7 +292,7 @@ describe 'Enum Validator unit tests', ->
     expect(@import._generateUpdateAction(enumSetAttributeMultiValue, sampleProductType.attributes[3])).toEqual expectedUpdateActionMultiValue
     expect(@import._generateUpdateAction(enumSetAttribute, sampleProductType.attributes[3])).toEqual expectedUpdateAction
 
-  it ' :: should generate correct list of update actions', (done) ->
+  it ' :: should generate correct list of update actions', ->
     enumAttributes = [
       name: 'sample-lenum-attribute'
       value: 'lenum-key-2'
@@ -338,12 +338,8 @@ describe 'Enum Validator unit tests', ->
         label: 'enum-set-5-key'
     ]
 
-    @import._validateEnums(enumAttributes, sampleProductType)
-    .then (updateActions) ->
-      expect(updateActions).toEqual expectedUpdateActions
-      done()
-    .catch (err) ->
-      done(err)
+    updateActions = @import._validateEnums(enumAttributes, sampleProductType)
+    expect(updateActions).toEqual expectedUpdateActions
 
   it ' :: should detect already generated enums', ->
     @import._cache.generatedEnums['sample-lenum-attribute-lenum-key-2'] = 'lenum-key-2'

--- a/test/enum-validator.spec.coffee
+++ b/test/enum-validator.spec.coffee
@@ -116,35 +116,35 @@ describe 'Enum Validator unit tests', ->
 
     @import = new EnumValidator @logger, null
 
-  it ' :: should initialize', ->
+  it ' should initialize', ->
     expect(@import).toBeDefined()
 
-  it ' :: should filter enum and lenum attributes', ->
+  it ' should filter enum and lenum attributes', ->
     enums = _.filter(sampleProductType.attributes, @import._enumLenumFilterPredicate)
     expect(_.size enums).toBe 2
 
-  it ' :: should filter set of enum attributes', ->
+  it ' should filter set of enum attributes', ->
     enums = _.filter(sampleProductType.attributes, @import._enumSetFilterPredicate)
     expect(_.size enums).toBe 1
 
-  it ' :: should filter set of lenum attributes', ->
+  it ' should filter set of lenum attributes', ->
     enums = _.filter(sampleProductType.attributes, @import._lenumSetFilterPredicate)
     expect(_.size enums).toBe 1
 
-  it ' :: should extract enum attributes from product type', ->
+  it ' should extract enum attributes from product type', ->
     enums = @import._extractEnumAttributesFromProductType(sampleProductType)
     expect(_.size enums).toBe 4
 
-  it ' :: should fetch enum attributes from sample product type', ->
+  it ' should fetch enum attributes from sample product type', ->
     enums = @import._fetchEnumAttributesOfProductType(sampleProductType)
     expect(_.size enums).toBe 4
 
-  it ' :: should fetch enum attribute names of sample product type', ->
+  it ' should fetch enum attribute names of sample product type', ->
     expectedNames = ['sample-lenum-attribute', 'sample-enum-attribute', 'sample-set-enum-attribute', 'sample-set-lenum-attribute']
     enumNames = @import._fetchEnumAttributeNamesOfProductType(sampleProductType)
     expect(enumNames).toEqual expectedNames
 
-  it ' :: should fetch enum attribute names of sample product type from cache', ->
+  it ' should fetch enum attribute names of sample product type from cache', ->
     spyOn(@import, '_fetchEnumAttributesOfProductType').andCallThrough()
     @import._fetchEnumAttributeNamesOfProductType(sampleProductType)
     enumNames = @import._fetchEnumAttributeNamesOfProductType(sampleProductType)
@@ -152,7 +152,7 @@ describe 'Enum Validator unit tests', ->
     expect(@import._fetchEnumAttributesOfProductType.calls.length).toEqual 1
     expect(@import._cache.productTypeEnumMap["#{sampleProductType.id}_names"]).toBeDefined()
 
-  it ' :: should detect enum attribute', ->
+  it ' should detect enum attribute', ->
     sampleEnumAttribute =
       name: 'sample-enum-attribute'
     sampleAttribute =
@@ -161,11 +161,11 @@ describe 'Enum Validator unit tests', ->
     expect(@import._isEnumVariantAttribute(sampleEnumAttribute, enumAttributeNames)).toBeTruthy()
     expect(@import._isEnumVariantAttribute(sampleAttribute, enumAttributeNames)).toBeFalsy()
 
-  it ' :: should fetch enum attributes from sample variant', ->
+  it ' should fetch enum attributes from sample variant', ->
     enums = @import._fetchEnumAttributesFromVariant(sampleVariant,sampleProductType)
     expect(_.size enums).toBe 3
 
-  it ' :: should fetch all enum attributes from all product variants', ->
+  it ' should fetch all enum attributes from all product variants', ->
     sampleProduct =
       name: 'sample Product'
       productType:
@@ -180,7 +180,7 @@ describe 'Enum Validator unit tests', ->
     enums = @import._fetchEnumAttributesFromProduct(sampleProduct, sampleProductType)
     expect(_.size enums).toBe 9
 
-  it ' :: should detect enum key correctly', ->
+  it ' should detect enum key correctly', ->
     enumAttributeTrue =
       name: 'sample-enum-attribute'
       value: 'enum-2-key'
@@ -222,7 +222,7 @@ describe 'Enum Validator unit tests', ->
     expect(@import._isEnumKeyPresent(enumSetAttributeTrue, sampleProductType.attributes[3])).toBeDefined()
     expect(@import._isEnumKeyPresent(enumSetAttributeFalse, sampleProductType.attributes[3])).toBeUndefined()
 
-  it ' :: should generate correct enum update action', ->
+  it ' should generate correct enum update action', ->
     enumAttribute =
       name: 'sample-enum-attribute'
       value: 'enum-3-key'
@@ -236,7 +236,7 @@ describe 'Enum Validator unit tests', ->
 
     expect(@import._generateUpdateAction(enumAttribute, sampleProductType.attributes[2])).toEqual expectedUpdateAction
 
-  it ' :: should generate correct lenum update action', ->
+  it ' should generate correct lenum update action', ->
     lenumAttribute =
       name: 'sample-lenum-attribute'
       value: 'lenum-3-key'
@@ -255,7 +255,7 @@ describe 'Enum Validator unit tests', ->
 
     expect(@import._generateUpdateAction(lenumAttribute, sampleProductType.attributes[1])).toEqual expectedUpdateAction
 
-  it ' :: should generate correct enum set update action', ->
+  it ' should generate correct enum set update action', ->
     enumSetAttributeMultiValue =
       name: 'sample-set-enum-attribute'
       value: [
@@ -292,7 +292,7 @@ describe 'Enum Validator unit tests', ->
     expect(@import._generateUpdateAction(enumSetAttributeMultiValue, sampleProductType.attributes[3])).toEqual expectedUpdateActionMultiValue
     expect(@import._generateUpdateAction(enumSetAttribute, sampleProductType.attributes[3])).toEqual expectedUpdateAction
 
-  it ' :: should generate correct list of update actions', ->
+  it ' should generate correct list of update actions', ->
     enumAttributes = [
       name: 'sample-lenum-attribute'
       value: 'lenum-key-2'
@@ -341,7 +341,7 @@ describe 'Enum Validator unit tests', ->
     updateActions = @import._validateEnums(enumAttributes, sampleProductType)
     expect(updateActions).toEqual expectedUpdateActions
 
-  it ' :: should detect already generated enums', ->
+  it ' should detect already generated enums', ->
     @import._cache.generatedEnums['sample-lenum-attribute-lenum-key-2'] = 'lenum-key-2'
     @import._cache.generatedEnums['sample-set-enum-attribute-enum-set-2-key'] = 'enum-set-2-key'
     @import._cache.generatedEnums['sample-lenum-attribute-lenum-3-key'] = 'lenum-3-key'

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -21,13 +21,13 @@ cleanup = (logger, client) ->
   debug "Deleting old product entries..."
   client.products.all().fetch()
   .then (result) ->
-    Promise.all _.map result.body.results, (e) ->
+    Promise.map result.body.results, (e) ->
       client.products.byId(e.id).delete(e.version)
   .then (results) ->
     debug "#{_.size results} products deleted."
     client.productTypes.where('name="Sample Product Type"').fetch()
   .then (result) ->
-    Promise.all _.map result.body.results, (e) ->
+    Promise.map result.body.results, (e) ->
       client.productTypes.byId(e.id).delete(e.version)
   .then (result) ->
     debug "#{_.size result} product type(s) deleted."

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -24,7 +24,12 @@ cleanup = (logger, client) ->
     Promise.all _.map result.body.results, (e) ->
       client.products.byId(e.id).delete(e.version)
   .then (results) ->
-    debug "#{_.size results} deleted."
+    debug "#{_.size results} products deleted."
+    client.productTypes.where("name=\"Sample Product Type\"").fetch()
+  .then (result) ->
+    client.productTypes.byId(result.body.results[0].id).delete(result.body.results[0].version)
+  .then (result) ->
+    debug "#{_.size result} product type(s) deleted."
     Promise.resolve()
 
 ensureResource = (service, predicate, sampleData) ->

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -89,229 +89,228 @@ describe 'Product import integration tests', ->
     .catch (err) -> done(_.prettify err)
   , 10000 # 10sec
 
-  describe 'JSON file', ->
 
-    it 'should import two new products', (done) ->
-      sampleImport = _.deepClone(sampleImportJson)
+  it ' should import two new products', (done) ->
+    sampleImport = _.deepClone(sampleImportJson)
+    @import._processBatches(sampleImport.products)
+    .then =>
+      expect(@import._summary.created).toBe 2
+      expect(@import._summary.updated).toBe 0
+      @client.productProjections.staged(true).fetch()
+    .then (result) =>
+      fetchedProducts = result.body.results
+      expect(_.size fetchedProducts).toBe 2
+      fetchedSkus = @import._extractUniqueSkus(fetchedProducts)
+      sampleSkus = @import._extractUniqueSkus(sampleImport.products)
+      commonSkus = _.intersection(sampleSkus,fetchedSkus)
+      expect(_.size commonSkus).toBe _.size sampleSkus
+      predicate = "masterVariant(sku=\"#{sampleImport.products[0].masterVariant.sku}\")"
+      @client.productProjections.where(predicate).staged(true).fetch()
+    .then (result) ->
+      fetchedProduct = result.body.results
+      expect(_.size fetchedProduct[0].variants).toBe _.size sampleImport.products[0].variants
+      expect(fetchedProduct[0].name).toEqual sampleImport.products[0].name
+      expect(fetchedProduct[0].slug).toEqual sampleImport.products[0].slug
+      done()
+    .catch done
+  , 10000
+
+  it ' should do nothing for empty products list', (done) ->
+    @import._processBatches([])
+    .then =>
+      expect(@import._summary.created).toBe 0
+      expect(@import._summary.updated).toBe 0
+      done()
+    .catch done
+  , 10000
+
+  it ' should generate missing slug', (done) ->
+    sampleImport = _.deepClone(sampleImportJson)
+    delete sampleImport.products[0].slug
+    delete sampleImport.products[1].slug
+
+    spyOn(@import, "_generateUniqueToken").andReturn("#{frozenTimeStamp}")
+    @import._processBatches(sampleImport.products)
+    .then =>
+      expect(@import._summary.created).toBe 2
+      expect(@import._summary.updated).toBe 0
+      predicate = "masterVariant(sku=\"#{sampleImport.products[0].masterVariant.sku}\")"
+      @client.productProjections.where(predicate).staged(true).fetch()
+    .then (result) ->
+      fetchedProduct = result.body.results
+      expect(fetchedProduct[0].slug.en).toBe "product-sync-test-product-1-#{frozenTimeStamp}"
+      done()
+    .catch done
+  , 10000
+
+  it ' should update existing product',  (done) ->
+    sampleImport = _.deepClone(sampleImportJson)
+    sampleUpdateRef = _.deepClone(sampleImportJson)
+    sampleUpdate = _.deepClone(sampleImportJson)
+    sampleUpdate.products = _.without(sampleUpdateRef.products,sampleUpdateRef.products[1])
+    sampleUpdate.products[0].variants = _.without(sampleUpdateRef.products[0].variants,sampleUpdateRef.products[0].variants[1])
+    sampleImport.products[0].name.de = 'Product_Sync_Test_Product_1_German'
+    sampleAttribute1 =
+      name: 'product_id'
+      value: 'sampe_product_id1'
+    sampleImport.products[0].masterVariant.attributes.push(sampleAttribute1)
+    sampleImport.products[0].variants[0].attributes.push(sampleAttribute1)
+    samplePrice =
+      value:
+        centAmount: 666
+        currencyCode: 'JPY'
+      country: 'JP'
+    sampleImport.products[0].variants[0].prices = [samplePrice]
+
+    spyOn(@import.sync, 'buildActions').andCallThrough()
+    @import._processBatches(sampleUpdate.products)
+    .then =>
+      expect(@import._summary.created).toBe 1
+      @import._resetSummary()
+      @import._resetCache()
       @import._processBatches(sampleImport.products)
-      .then =>
-        expect(@import._summary.created).toBe 2
-        expect(@import._summary.updated).toBe 0
-        @client.productProjections.staged(true).fetch()
-      .then (result) =>
-        fetchedProducts = result.body.results
-        expect(_.size fetchedProducts).toBe 2
-        fetchedSkus = @import._extractUniqueSkus(fetchedProducts)
-        sampleSkus = @import._extractUniqueSkus(sampleImport.products)
-        commonSkus = _.intersection(sampleSkus,fetchedSkus)
-        expect(_.size commonSkus).toBe _.size sampleSkus
-        predicate = "masterVariant(sku=\"#{sampleImport.products[0].masterVariant.sku}\")"
-        @client.productProjections.where(predicate).staged(true).fetch()
-      .then (result) ->
-        fetchedProduct = result.body.results
-        expect(_.size fetchedProduct[0].variants).toBe _.size sampleImport.products[0].variants
-        expect(fetchedProduct[0].name).toEqual sampleImport.products[0].name
-        expect(fetchedProduct[0].slug).toEqual sampleImport.products[0].slug
-        done()
-      .catch done
-    , 10000
+    .then =>
+      expect(@import._summary.created).toBe 1
+      expect(@import._summary.updated).toBe 1
+      expect(@import.sync.buildActions).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(Object), ['sample_attribute_1'])
+      predicate = "masterVariant(sku=\"#{sampleUpdate.products[0].masterVariant.sku}\")"
+      @client.productProjections.where(predicate).staged(true).fetch()
+    .then (result) ->
+      expect(_.size result.body.results[0].variants).toBe 2
+      done()
+    .catch (err) -> done(_.prettify err.body)
+  , 10000
 
-    it 'should do nothing for empty products list', (done) ->
-      @import._processBatches([])
-      .then =>
-        expect(@import._summary.created).toBe 0
-        expect(@import._summary.updated).toBe 0
-        done()
-      .catch done
-    , 10000
+  it ' should continue on error - duplicate slug', (done) ->
+    # FIXME: looks like the API doesn't correctly validate for duplicate slugs
+    # for 2 concurrent requests (this happens randomly).
+    # For now we have to test it as 2 separate imports.
+    sampleImport = _.deepClone sampleImportJson
+    @import._processBatches([sampleImport.products[0]])
+    .then =>
+      expect(@import._summary.created).toBe
+      sampleImport2 = _.deepClone sampleImportJson
+      sampleImport2.products[1].slug.en = 'product-sync-test-product-1'
+      @import._resetSummary()
+      @import._processBatches([sampleImport2.products[1]])
+    .then =>
+      # import should fail because product 1 has same slug
+      expect(@import._summary.failed).toBe 1
+      expect(@import._summary.created).toBe 0
+      errorJson = require path.join(@import.errorDir,'error-1.json')
+      expect(errorJson.message).toEqual "A duplicate value '\"product-sync-test-product-1\"' exists for field 'slug'."
+      done()
+    .catch done
 
-    it 'should generate missing slug', (done) ->
-      sampleImport = _.deepClone(sampleImportJson)
-      delete sampleImport.products[0].slug
+  it ' should continue of error - missing product name', (done) ->
+    cleanup(@logger, @client)
+    .then => ensureResource(@client.productTypes, 'name="Sample Product Type"', sampleProductType)
+    .then =>
+      sampleImport = _.deepClone sampleImportJson
+      delete sampleImport.products[1].name
       delete sampleImport.products[1].slug
-
-      spyOn(@import, "_generateUniqueToken").andReturn("#{frozenTimeStamp}")
       @import._processBatches(sampleImport.products)
       .then =>
-        expect(@import._summary.created).toBe 2
-        expect(@import._summary.updated).toBe 0
-        predicate = "masterVariant(sku=\"#{sampleImport.products[0].masterVariant.sku}\")"
-        @client.productProjections.where(predicate).staged(true).fetch()
-      .then (result) ->
-        fetchedProduct = result.body.results
-        expect(fetchedProduct[0].slug.en).toBe "product-sync-test-product-1-#{frozenTimeStamp}"
-        done()
-      .catch done
-    , 10000
-
-    it 'should update existing product',  (done) ->
-      sampleImport = _.deepClone(sampleImportJson)
-      sampleUpdateRef = _.deepClone(sampleImportJson)
-      sampleUpdate = _.deepClone(sampleImportJson)
-      sampleUpdate.products = _.without(sampleUpdateRef.products,sampleUpdateRef.products[1])
-      sampleUpdate.products[0].variants = _.without(sampleUpdateRef.products[0].variants,sampleUpdateRef.products[0].variants[1])
-      sampleImport.products[0].name.de = 'Product_Sync_Test_Product_1_German'
-      sampleAttribute1 =
-        name: 'product_id'
-        value: 'sampe_product_id1'
-      sampleImport.products[0].masterVariant.attributes.push(sampleAttribute1)
-      sampleImport.products[0].variants[0].attributes.push(sampleAttribute1)
-      samplePrice =
-        value:
-          centAmount: 666
-          currencyCode: 'JPY'
-        country: 'JP'
-      sampleImport.products[0].variants[0].prices = [samplePrice]
-
-      spyOn(@import.sync, 'buildActions').andCallThrough()
-      @import._processBatches(sampleUpdate.products)
-      .then =>
-        expect(@import._summary.created).toBe 1
-        @import._resetSummary()
-        @import._resetCache()
-        @import._processBatches(sampleImport.products)
-      .then =>
-        expect(@import._summary.created).toBe 1
-        expect(@import._summary.updated).toBe 1
-        expect(@import.sync.buildActions).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(Object), ['sample_attribute_1'])
-        predicate = "masterVariant(sku=\"#{sampleUpdate.products[0].masterVariant.sku}\")"
-        @client.productProjections.where(predicate).staged(true).fetch()
-      .then (result) ->
-        expect(_.size result.body.results[0].variants).toBe 2
-        done()
-      .catch (err) -> done(_.prettify err.body)
-    , 10000
-
-    it ' :: should continue on error - duplicate slug', (done) ->
-      # FIXME: looks like the API doesn't correctly validate for duplicate slugs
-      # for 2 concurrent requests (this happens randomly).
-      # For now we have to test it as 2 separate imports.
-      sampleImport = _.deepClone sampleImportJson
-      @import._processBatches([sampleImport.products[0]])
-      .then =>
-        expect(@import._summary.created).toBe
-        sampleImport2 = _.deepClone sampleImportJson
-        sampleImport2.products[1].slug.en = 'product-sync-test-product-1'
-        @import._resetSummary()
-        @import._processBatches([sampleImport2.products[1]])
-      .then =>
-        # import should fail because product 1 has same slug
         expect(@import._summary.failed).toBe 1
-        expect(@import._summary.created).toBe 0
-        errorJson = require path.join(@import.errorDir,'error-1.json')
-        expect(errorJson.message).toEqual "A duplicate value '\"product-sync-test-product-1\"' exists for field 'slug'."
+        expect(@import._summary.created).toBe 1
         done()
       .catch done
 
-    it ' :: should continue of error - missing product name', (done) ->
-      cleanup(@logger, @client)
-      .then => ensureResource(@client.productTypes, 'name="Sample Product Type"', sampleProductType)
-      .then =>
-        sampleImport = _.deepClone sampleImportJson
-        delete sampleImport.products[1].name
-        delete sampleImport.products[1].slug
-        @import._processBatches(sampleImport.products)
-        .then =>
-          expect(@import._summary.failed).toBe 1
-          expect(@import._summary.created).toBe 1
-          done()
-        .catch done
+  it ' should handle set type attributes correctly', (done) ->
+    sampleImport = _.deepClone sampleImportJson
 
-    it ':: should handle set type attributes correctly', (done) ->
-      sampleImport = _.deepClone sampleImportJson
+    setTextAttribute =
+      name: 'sample_set_text'
+      value: ['text_1', 'text_2']
 
-      setTextAttribute =
-        name: 'sample_set_text'
-        value: ['text_1', 'text_2']
+    setTextAttributeUpdated =
+      name: 'sample_set_text'
+      value: ['text_1', 'text_2', 'text_3']
 
-      setTextAttributeUpdated =
-        name: 'sample_set_text'
-        value: ['text_1', 'text_2', 'text_3']
+    sampleImport.products[0].masterVariant.attributes.push setTextAttribute
 
-      sampleImport.products[0].masterVariant.attributes.push setTextAttribute
+    predicate = 'masterVariant(sku="B3-717597")'
+    @import._processBatches(sampleImport.products)
+    .then =>
+      expect(@import._summary.created).toBe 2
+      @client.productProjections.where(predicate).staged(true).fetch()
+    .then (result) =>
+      expect(result.body.results[0].masterVariant.attributes[0].value).toEqual setTextAttribute.value
+      sampleUpdate = _.deepClone sampleImportJson
+      sampleUpdate.products[0].masterVariant.attributes.push setTextAttributeUpdated
+      @import._processBatches(sampleUpdate.products)
+    .then =>
+      expect(@import._summary.updated).toBe 1
+      @client.productProjections.where(predicate).staged(true).fetch()
+    .then (result) ->
+      expect(result.body.results[0].masterVariant.attributes[0].value).toEqual setTextAttributeUpdated.value
+      done()
+    .catch done
+  , 10000
 
-      predicate = 'masterVariant(sku="B3-717597")'
-      @import._processBatches(sampleImport.products)
-      .then =>
-        expect(@import._summary.created).toBe 2
-        @client.productProjections.where(predicate).staged(true).fetch()
-      .then (result) =>
-        expect(result.body.results[0].masterVariant.attributes[0].value).toEqual setTextAttribute.value
-        sampleUpdate = _.deepClone sampleImportJson
-        sampleUpdate.products[0].masterVariant.attributes.push setTextAttributeUpdated
-        @import._processBatches(sampleUpdate.products)
-      .then =>
-        expect(@import._summary.updated).toBe 1
-        @client.productProjections.where(predicate).staged(true).fetch()
-      .then (result) ->
-        expect(result.body.results[0].masterVariant.attributes[0].value).toEqual setTextAttributeUpdated.value
-        done()
-      .catch done
-    , 10000
+  it ' should filter unknown attributes and import product without errors', (done) ->
+    sampleImport = _.deepClone sampleImportJson
 
-    it ':: should filter unknown attributes and import product without errors', (done) ->
-      sampleImport = _.deepClone sampleImportJson
+    unknownAttribute =
+      name: 'unknownAttribute'
+      value: 'unknown value'
 
-      unknownAttribute =
-        name: 'unknownAttribute'
-        value: 'unknown value'
+    sampleImport.products[0].masterVariant.attributes.push unknownAttribute
 
-      sampleImport.products[0].masterVariant.attributes.push unknownAttribute
+    @import._processBatches(sampleImport.products)
+    .then =>
+      expect(@import._summary.created).toBe 2
+      done()
+    .catch done
+  , 10000
 
-      @import._processBatches(sampleImport.products)
-      .then =>
-        expect(@import._summary.created).toBe 2
-        done()
-      .catch done
-    , 10000
+  it ' should update/create product with a new enum key', (done) ->
+    @logger.info ':: should update/create product with a new enum key'
+    sampleImport = _.deepClone sampleImportJson
 
-    it ':: should update/create product with a new enum key', (done) ->
-      @logger.info ':: should update/create product with a new enum key'
-      sampleImport = _.deepClone sampleImportJson
+    existingEnumKeyAttr =
+      name: 'sample_enum_attribute'
+      value: 'enum-1-key'
 
-      existingEnumKeyAttr =
-        name: 'sample_enum_attribute'
-        value: 'enum-1-key'
+    newEnumKeyAttr =
+      name: 'sample_enum_attribute'
+      value: 'enum-new-key'
 
-      newEnumKeyAttr =
-        name: 'sample_enum_attribute'
-        value: 'enum-new-key'
+    expectedNewEnumKeyAttr =
+      name: 'sample_enum_attribute'
+      value:
+        key: 'enum-new-key'
+        label: 'enum-new-key'
 
-      expectedNewEnumKeyAttr =
-        name: 'sample_enum_attribute'
-        value:
-          key: 'enum-new-key'
-          label: 'enum-new-key'
+    newEnumKeyAttr2 =
+      name: 'sample_enum_attribute'
+      value: 'enum-3-new-key'
 
-      newEnumKeyAttr2 =
-        name: 'sample_enum_attribute'
-        value: 'enum-3-new-key'
+    expectedNewEnumKeyAttr2 =
+      name: 'sample_enum_attribute'
+      value:
+        key: 'enum-3-new-key'
+        label: 'enum-3-new-key'
 
-      expectedNewEnumKeyAttr2 =
-        name: 'sample_enum_attribute'
-        value:
-          key: 'enum-3-new-key'
-          label: 'enum-3-new-key'
+    sampleImport.products[0].masterVariant.attributes.push(existingEnumKeyAttr)
+    sampleImport.products[0].masterVariant.attributes.push(newEnumKeyAttr)
+    sampleImport.products[0].masterVariant.attributes.push(newEnumKeyAttr2)
+    sampleImport.products[1].variants[0].attributes.push(existingEnumKeyAttr)
+    sampleImport.products[1].variants[0].attributes.push(newEnumKeyAttr)
 
-      sampleImport.products[0].masterVariant.attributes.push(existingEnumKeyAttr)
-      sampleImport.products[0].masterVariant.attributes.push(newEnumKeyAttr)
-      sampleImport.products[0].masterVariant.attributes.push(newEnumKeyAttr2)
-      sampleImport.products[1].variants[0].attributes.push(existingEnumKeyAttr)
-      sampleImport.products[1].variants[0].attributes.push(newEnumKeyAttr)
+    predicate = 'masterVariant(sku="B3-717597")'
 
-      predicate = 'masterVariant(sku="B3-717597")'
-
-      @import._processBatches(sampleImport.products)
-      .then =>
-        expect(@import._summary.created).toBe 2
-        @client.productProjections.where(predicate).staged(true).fetch()
-      .then (result) ->
-        filterPredicate1 = (element) -> _.isEqual(element,expectedNewEnumKeyAttr)
-        filterPredicate2 = (element) -> _.isEqual(element,expectedNewEnumKeyAttr2)
-        expect(_.find(result.body.results[0].masterVariant.attributes, filterPredicate1)).toBeDefined()
-        expect(_.find(result.body.results[0].masterVariant.attributes, filterPredicate2)).toBeDefined()
-        done()
-      .catch done
+    @import._processBatches(sampleImport.products)
+    .then =>
+      expect(@import._summary.created).toBe 2
+      @client.productProjections.where(predicate).staged(true).fetch()
+    .then (result) ->
+      filterPredicate1 = (element) -> _.isEqual(element,expectedNewEnumKeyAttr)
+      filterPredicate2 = (element) -> _.isEqual(element,expectedNewEnumKeyAttr2)
+      expect(_.find(result.body.results[0].masterVariant.attributes, filterPredicate1)).toBeDefined()
+      expect(_.find(result.body.results[0].masterVariant.attributes, filterPredicate2)).toBeDefined()
+      done()
+    .catch done
 
 
 

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -85,7 +85,7 @@ describe 'Product import integration tests', ->
 
   describe 'JSON file', ->
 
-    it 'should import two new products', (done) ->
+    xit 'should import two new products', (done) ->
       sampleImport = _.deepClone(sampleImportJson)
       @import._processBatches(sampleImport.products)
       .then =>
@@ -110,7 +110,7 @@ describe 'Product import integration tests', ->
       .catch done
     , 10000
 
-    it 'should do nothing for empty products list', (done) ->
+    xit 'should do nothing for empty products list', (done) ->
       @import._processBatches([])
       .then =>
         expect(@import._summary.created).toBe 0
@@ -119,7 +119,7 @@ describe 'Product import integration tests', ->
       .catch done
     , 10000
 
-    it 'should generate missing slug', (done) ->
+    xit 'should generate missing slug', (done) ->
       sampleImport = _.deepClone(sampleImportJson)
       delete sampleImport.products[0].slug
       delete sampleImport.products[1].slug
@@ -138,7 +138,7 @@ describe 'Product import integration tests', ->
       .catch done
     , 10000
 
-    it 'should update existing product',  (done) ->
+    xit 'should update existing product',  (done) ->
       sampleImport = _.deepClone(sampleImportJson)
       sampleUpdateRef = _.deepClone(sampleImportJson)
       sampleUpdate = _.deepClone(sampleImportJson)
@@ -176,7 +176,7 @@ describe 'Product import integration tests', ->
       .catch (err) -> done(_.prettify err.body)
     , 10000
 
-    it ' :: should continue on error - duplicate slug', (done) ->
+    xit ' :: should continue on error - duplicate slug', (done) ->
       # FIXME: looks like the API doesn't correctly validate for duplicate slugs
       # for 2 concurrent requests (this happens randomly).
       # For now we have to test it as 2 separate imports.
@@ -197,7 +197,7 @@ describe 'Product import integration tests', ->
         done()
       .catch done
 
-    it ' :: should continue of error - missing product name', (done) ->
+    xit ' :: should continue of error - missing product name', (done) ->
       cleanup(@logger, @client)
       .then =>
         sampleImport = _.deepClone sampleImportJson
@@ -210,7 +210,7 @@ describe 'Product import integration tests', ->
           done()
         .catch done
 
-    it ':: should handle set type attributes correctly', (done) ->
+    xit ':: should handle set type attributes correctly', (done) ->
       sampleImport = _.deepClone sampleImportJson
 
       setTextAttribute =
@@ -242,7 +242,7 @@ describe 'Product import integration tests', ->
       .catch done
     , 10000
 
-    it ':: should filter unknown attributes and import product without errors', (done) ->
+    xit ':: should filter unknown attributes and import product without errors', (done) ->
       sampleImport = _.deepClone sampleImportJson
 
       unknownAttribute =
@@ -257,6 +257,35 @@ describe 'Product import integration tests', ->
         done()
       .catch done
     , 10000
+
+    it ':: should update/create product with a new enum key', (done) ->
+      sampleImport = _.deepClone sampleImportJson
+
+      existingEnumKeyAttr =
+        name: 'sample_enum_attribute'
+        value: 'enum-1-key'
+
+      newEnumKeyAttr =
+        name: 'sample_enum_attribute'
+        value: 'enum-new-key'
+
+      newEnumKeyAttr2 =
+        name: 'sample_enum_attribute'
+        value: 'Enum 3 New Key'
+
+      sampleImport.products[0].masterVariant.attributes.push(existingEnumKeyAttr)
+      sampleImport.products[0].masterVariant.attributes.push(newEnumKeyAttr)
+      sampleImport.products[0].masterVariant.attributes.push(newEnumKeyAttr2)
+      sampleImport.products[1].variants[0].attributes.push(existingEnumKeyAttr)
+      sampleImport.products[1].variants[0].attributes.push(newEnumKeyAttr)
+
+      @import._processBatches(sampleImport.products)
+      .then =>
+        expect(@import._summary.created).toBe 2
+        done()
+      .catch done
+
+
 
 
 

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -277,9 +277,21 @@ describe 'Product import integration tests', ->
         name: 'sample_enum_attribute'
         value: 'enum-new-key'
 
+      expectedNewEnumKeyAttr =
+        name: 'sample_enum_attribute'
+        value:
+          key: 'enum-new-key'
+          label: 'enum-new-key'
+
       newEnumKeyAttr2 =
         name: 'sample_enum_attribute'
         value: 'enum-3-new-key'
+
+      expectedNewEnumKeyAttr2 =
+        name: 'sample_enum_attribute'
+        value:
+          key: 'enum-3-new-key'
+          label: 'enum-3-new-key'
 
       sampleImport.products[0].masterVariant.attributes.push(existingEnumKeyAttr)
       sampleImport.products[0].masterVariant.attributes.push(newEnumKeyAttr)
@@ -287,9 +299,17 @@ describe 'Product import integration tests', ->
       sampleImport.products[1].variants[0].attributes.push(existingEnumKeyAttr)
       sampleImport.products[1].variants[0].attributes.push(newEnumKeyAttr)
 
+      predicate = 'masterVariant(sku="B3-717597")'
+
       @import._processBatches(sampleImport.products)
       .then =>
         expect(@import._summary.created).toBe 2
+        @client.productProjections.where(predicate).staged(true).fetch()
+      .then (result) ->
+        filterPredicate1 = (element) -> _.isEqual(element,expectedNewEnumKeyAttr)
+        filterPredicate2 = (element) -> _.isEqual(element,expectedNewEnumKeyAttr2)
+        expect(_.find(result.body.results[0].masterVariant.attributes, filterPredicate1)).toBeDefined()
+        expect(_.find(result.body.results[0].masterVariant.attributes, filterPredicate2)).toBeDefined()
         done()
       .catch done
 

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -259,6 +259,7 @@ describe 'Product import integration tests', ->
     , 10000
 
     it ':: should update/create product with a new enum key', (done) ->
+      @logger.info ':: should update/create product with a new enum key'
       sampleImport = _.deepClone sampleImportJson
 
       existingEnumKeyAttr =

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -760,7 +760,48 @@ describe 'ProductImport unit tests', ->
       .catch (err) ->
         done(err)
 
+    it ' :: should filter unique update actions', ->
+      sampleUpdateAction1 =
+        action: 'addPlainEnumValue'
+        attributeName: 'sample-enum-attribute'
+        value:
+          key: 'enum-1-key'
+          label: 'enum-1-key'
 
+      sampleUpdateAction2 =
+        action: 'addPlainEnumValue'
+        attributeName: 'sample-enum-attribute'
+        value:
+          key: 'enum-2-key'
+          label: 'enum-2-key'
 
+      sampleInput =
+        product_type_internal_id_1: [
+          sampleUpdateAction1
+        ,
+          sampleUpdateAction2
+        ,
+          sampleUpdateAction1
+        ]
+        product_type_internal_id_2: [
+          sampleUpdateAction2
+        ,
+          sampleUpdateAction1
+        ,
+          sampleUpdateAction2
+        ]
 
+      expectedOutput =
+        product_type_internal_id_1: [
+          sampleUpdateAction1
+        ,
+          sampleUpdateAction2
+        ]
+        product_type_internal_id_2: [
+          sampleUpdateAction2
+        ,
+          sampleUpdateAction1
+        ]
+
+      expect(@import._filterUniqueUpdateActions(sampleInput)).toEqual expectedOutput
 

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -494,6 +494,8 @@ describe 'ProductImport unit tests', ->
       spyOn(@import, "_createProductFetchBySkuQueryPredicate").andCallThrough()
       spyOn(@import.client.productProjections,"fetch").andCallFake -> Promise.resolve({body: {results: existingProducts}})
       spyOn(@import, "_createOrUpdate").andCallFake -> Promise.settle([Promise.resolve({statusCode: 201}), Promise.resolve({statusCode: 200})])
+      spyOn(@import, "_ensureProductTypesInMemory").andCallFake -> Promise.resolve()
+      @import.ensureEnums = false
       @import._processBatches(sampleProducts)
       .then =>
         expect(@import._extractUniqueSkus).toHaveBeenCalled()


### PR DESCRIPTION
To ensure that any new enum keys received in the product data are added to the product type, before the product data is imported.