### PR TITLE
Add unknown attribute names to summary.

### DIFF
--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -65,6 +65,7 @@ class ProductImport
       failed: 0
       productTypeUpdated: 0
       errorDir: @errorDir
+    if @filterUnknownAttributes then @_summary.unknownAttributeNames = []
 
   summaryReport: (filename) ->
     if @_summary.created is 0 and @_summary.updated is 0
@@ -189,7 +190,7 @@ class ProductImport
   _filterAttributes: (product) =>
     new Promise (resolve) =>
       if @filterUnknownAttributes
-        @unknownAttributesFilter.filter(@_cache.productType[product.productType.id],product)
+        @unknownAttributesFilter.filter(@_cache.productType[product.productType.id],product, @_summary.unknownAttributeNames)
         .then (filteredProduct) ->
           resolve(filteredProduct)
       else

--- a/lib/unknown-attributes-filter.coffee
+++ b/lib/unknown-attributes-filter.coffee
@@ -10,7 +10,7 @@ class UnknownAttributesFilter
   constructor: (@logger) ->
     debug "Unknown Attributes Filter initialized."
 
-  filter: (productType, product) =>
+  filter: (productType, product, @collectedUnknownAttributeNames) =>
     if productType.attributes
       attrNameList = _.pluck(productType.attributes, 'name')
       Promise.all [
@@ -40,9 +40,15 @@ class UnknownAttributesFilter
     for attribute in attributes
       if @_isKnownAttribute(attribute, attrNameList)
         filteredAttributes.push attribute
+      else if @collectedUnknownAttributeNames
+        @_unknownAttributeNameCollector(attribute.name)
     Promise.resolve filteredAttributes
 
   _isKnownAttribute: (attribute, attrNameList) ->
     attribute.name in attrNameList
+
+  _unknownAttributeNameCollector: (attributeName) =>
+    if not _.contains(@collectedUnknownAttributeNames, attributeName)
+      @collectedUnknownAttributeNames.push(attributeName)
 
 module.exports = UnknownAttributesFilter

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -260,6 +260,7 @@ describe 'Product import integration tests', ->
     @import._processBatches(sampleImport.products)
     .then =>
       expect(@import._summary.created).toBe 2
+      expect(@import._summary.unknownAttributeNames).toEqual ['unknownAttribute']
       done()
     .catch done
   , 10000

--- a/test/unknown-attributes-filter.spec.coffee
+++ b/test/unknown-attributes-filter.spec.coffee
@@ -36,6 +36,12 @@ expectedAttributeList = [
   value: 'attributeValue'
 ]
 
+expectedUnknownAttributeList = [
+  'attributeName4'
+,
+  'attributeName5'
+]
+
 describe 'Unknown Attributes Filter unit tests', ->
 
   beforeEach ->
@@ -118,9 +124,11 @@ describe 'Unknown Attributes Filter unit tests', ->
         value: 'attributeValue'
       ]
 
-    @import.filter(productType,sampleProduct)
+    unknownAttributeList = []
+    @import.filter(productType,sampleProduct, unknownAttributeList)
     .then (product) ->
       expect(product).toEqual sampleExpectedProduct
+      expect(unknownAttributeList).toEqual expectedUnknownAttributeList
       done()
     .catch done
 


### PR DESCRIPTION
If `filterUnknownAttributes` is enabled
Summary will have a list of ignored attribute names.