### PR TITLE
Add -> ensure default attributes in product variants.

### DIFF
--- a/lib/ensure-default-attributes.coffee
+++ b/lib/ensure-default-attributes.coffee
@@ -1,0 +1,32 @@
+_ = require 'underscore'
+_.mixin require 'underscore-mixins'
+Promise = require 'bluebird'
+
+# Recives list of default attributes in the format:
+# [{ name: attributeName, value: defaultAttributeValue }, { name: attributeName, value: defaultAttributeValue }]
+class EnsureDefaultAttributes
+
+  constructor: (@logger, @defaultAttributes) ->
+    @logger.debug('Ensuring default attributes')
+
+  ensureDefaultAttributesInProduct: (product) =>
+    updatedProduct = _.deepClone(product)
+    updatedProduct.masterVariant = @_ensureInVariant(product.masterVariant)
+    updatedVariants = _.map(product.variants, @_ensureInVariant)
+    updatedProduct.variants = updatedVariants
+    Promise.resolve(updatedProduct)
+
+  _ensureInVariant: (variant) =>
+    if not variant.attributes
+      return variant
+    extendedAttributes = _.deepClone(variant.attributes)
+    for defaultAttribute in @defaultAttributes
+      if not @_isAttributeExisting(defaultAttribute, variant.attributes)
+        extendedAttributes.push(defaultAttribute)
+    variant.attributes = extendedAttributes
+    return variant
+
+  _isAttributeExisting: (defaultAttribute, attributeList) ->
+    _.findWhere(attributeList, { name: "#{defaultAttribute.name}" })
+
+module.exports = EnsureDefaultAttributes

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -6,3 +6,4 @@ module.exports =
   EnumValidator: require './enum-validator'
   UnknownAttributesFilter: require './unknown-attributes-filter'
   CommonUtils: require './common-utils'
+  EnsureDefaultAttributes: require './ensure-default-attributes'

--- a/lib/price-import.coffee
+++ b/lib/price-import.coffee
@@ -54,6 +54,13 @@ class PriceImport extends ProductImport
             Promise.resolve(@_summary)
     ,{concurrency: 1}
 
+  _handleFulfilledResponse: (r) =>
+    switch r.value().statusCode
+      when 201 then @_summary.created++
+      when 200 then @_summary.updated++
+      when 404 then @_summary.unknownSKUCount++
+      when 304 then @_summary.variantWithoutPriceUpdates++
+
   _preparePrices: (pricesToProcess) =>
     Promise.map pricesToProcess, (priceToProcess) =>
       @_preparePrice priceToProcess
@@ -93,6 +100,7 @@ class PriceImport extends ProductImport
 
     posts = _.map productsToProcess, (prodToProcess) =>
       existingProduct = @_isExistingEntry(prodToProcess, existingProducts)
+
       if existingProduct?
         synced = @sync.buildActions(prodToProcess, existingProduct)
         if synced.shouldUpdate()

--- a/readme/product-import.md
+++ b/readme/product-import.md
@@ -26,6 +26,7 @@ Accepts a list of products in a valid [JSON Schema](https://github.com/sphereio/
   * filterUnknownAttributes -> when set to `true` will ignore any attributes not defined in the product type of the product being imported. Default: `false`
   * ignoreSlugUpdates -> when set to `true` will ignore all slug updates for existing product updates. Default: `false` 
   * batchSize -> number of products to be processed in each batch. Default: 30
+  * defaultAttributes -> a list of attributes to be added to all variants if not existing
 
 #### Sample configuration object for cli:
 
@@ -37,7 +38,11 @@ Accepts a list of products in a valid [JSON Schema](https://github.com/sphereio/
       "filterUnknownAttributes": "true",
       "ignoreSlugUpdates": "true",
       "batchSize": 20,
-      "blackList": [ "images", "categories" ]
+      "blackList": [ "images", "categories" ],
+      "defaultAttributes": [
+        {"name": "attributeName", "value": "defaultValue"},
+        {"name": "attributeName", "value": "defaultValue"}
+      ]
     }
   
 ### Sample Inputs

--- a/test/ensure-default-attributes.spec.coffee
+++ b/test/ensure-default-attributes.spec.coffee
@@ -1,0 +1,85 @@
+_ = require 'underscore'
+_.mixin require 'underscore-mixins'
+{EnsureDefaultAttributes} = require '../lib'
+{ExtendedLogger} = require 'sphere-node-utils'
+package_json = require '../package.json'
+
+defaultAttributes = [
+  name: 'defaultAttribute1'
+  value: 'attributeValue1'
+,
+  name: 'defaultAttribute2'
+  value: 'attributeValue2'
+,
+  name: 'defaultAttribute3'
+  value: 'attributeValue3'
+]
+
+variantAttributes = [
+  name: 'attributeName1'
+  value: 'attributeValue1'
+,
+  name: 'attributeName2'
+  value: 'attributeValue2'
+,
+  name: 'attributeName3'
+  value: 'attributeValue3'
+,
+  name: 'attributeName4'
+  value: 'attributeValue4'
+]
+
+describe 'Ensure default attributes unit tests', ->
+
+  beforeEach ->
+    @logger = new ExtendedLogger
+    additionalFields:
+      project_key: 'ensureDefaultAttributes'
+    logConfig:
+      name: "#{package_json.name}-#{package_json.version}"
+      streams: [
+        { level: 'info', stream: process.stdout }
+      ]
+
+    @import = new EnsureDefaultAttributes(@logger, defaultAttributes)
+
+  it ' :: should initialize', ->
+    expect(@import).toBeDefined()
+
+  it ' :: should find existing attribute', ->
+    extendedVariantAttributes = _.deepClone(variantAttributes)
+    extendedVariantAttributes.push(defaultAttributes[0])
+    expect(@import._isAttributeExisting(defaultAttributes[0], extendedVariantAttributes)).toBeTruthy()
+    expect(@import._isAttributeExisting(defaultAttributes[1],variantAttributes)).toBeFalsy()
+
+  it ' :: should ensure default attributes in variant', ->
+    inputVariant = {}
+    extendedVariantAttributes = _.deepClone(variantAttributes)
+    extendedVariantAttributes.push(defaultAttributes[0])
+    inputVariant.attributes = extendedVariantAttributes
+    expectedVariant = _.deepClone(inputVariant)
+    expectedVariant.attributes.push(defaultAttributes[1])
+    expectedVariant.attributes.push(defaultAttributes[2])
+    expect(@import._ensureInVariant(inputVariant)).toEqual(expectedVariant)
+
+  it ' :: should ensure default attributes in product', (done) ->
+    inputVariant = {}
+    extendedVariantAttributes = _.deepClone(variantAttributes)
+    extendedVariantAttributes.push(defaultAttributes[0])
+    inputVariant.attributes = extendedVariantAttributes
+    expectedVariant = _.deepClone(inputVariant)
+    expectedVariant.attributes.push(defaultAttributes[1])
+    expectedVariant.attributes.push(defaultAttributes[2])
+    inputProduct = {}
+    inputProduct.masterVariant = inputVariant
+    inputProduct.variants = []
+    inputProduct.variants.push(inputVariant)
+    expectedProduct = {}
+    expectedProduct.masterVariant = expectedVariant
+    expectedProduct.variants = []
+    expectedProduct.variants.push(expectedVariant)
+    @import.ensureDefaultAttributesInProduct(inputProduct)
+    .then (updatedProduct) ->
+      expect(updatedProduct).toEqual(expectedProduct)
+      done()
+    .catch done

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -155,6 +155,18 @@ sampleReferenceCats =
     id: 'category_external_id2'
   ]
 
+sampleDefaultAttributes =
+  [
+    name: 'defaultAttribute1'
+    value: 'defaultAttributeValue'
+  ,
+    name: 'defaultAttribute2'
+    value: 'defaultAttributeValue'
+  ,
+    name: 'defaultAttribute3'
+    value: 'defaultAttributeValue'
+  ]
+
 describe 'ProductImport unit tests', ->
 
   beforeEach ->
@@ -176,6 +188,8 @@ describe 'ProductImport unit tests', ->
       errorLimit: 0
       ensureEnums: true
       blackList: ['prices']
+      defaultAttributes: sampleDefaultAttributes
+
 
     @import = new ProductImport @logger, Config
 
@@ -818,3 +832,32 @@ describe 'ProductImport unit tests', ->
 
       expect(@import._filterUniqueUpdateActions(sampleInput)).toEqual expectedOutput
 
+    it ' :: should check and add default attributes', (done) ->
+      sampleInput = _.deepClone sampleNewProduct
+      sampleInput.masterVariant = _.deepClone sampleMasterVariant
+      sampleInput.variants = []
+      sampleInput.variants.push _.deepClone(sampleVariant1)
+      sampleInput.variants.push _.deepClone(sampleVariant2)
+
+      sampleDefaultExistingAttr =
+        name: 'defaultAttribute1'
+        value: 'defaultExistingAttributeValue'
+
+      sampleInput.masterVariant.attributes.push sampleDefaultExistingAttr
+
+      expectedOutput = _.deepClone sampleNewProduct
+      expectedOutput.masterVariant = _.deepClone sampleMasterVariant
+      expectedOutput.variants = []
+      expectedOutput.variants.push _.deepClone(sampleVariant1)
+      expectedOutput.variants.push _.deepClone(sampleVariant2)
+
+      expectedOutput.masterVariant.attributes = expectedOutput.masterVariant.attributes.concat(_.deepClone(sampleDefaultAttributes))
+      expectedOutput.masterVariant.attributes[1].value = 'defaultExistingAttributeValue'
+      expectedOutput.variants[0].attributes = expectedOutput.variants[0].attributes.concat _.deepClone(sampleDefaultAttributes)
+      expectedOutput.variants[1].attributes = expectedOutput.variants[1].attributes.concat _.deepClone(sampleDefaultAttributes)
+
+      @import._ensureDefaultAttributesInProducts([sampleInput])
+      .then ->
+        expect(sampleInput).toEqual(expectedOutput)
+        done()
+      .catch(done)


### PR DESCRIPTION
Feature to specify a list of default attributes in all product variants.
* All variants are checked for the existence of default attributes 
* If not present, default attributes are added to the attributes list with specified default values

Use Case:
There are some attributes added to the variants by us for various requirements of handling and filtering product data on the frontend as well as for conditional checks by other sub processes such as stock import checking for certain attributes. These extra attributes are not provided in the export from the customers as they do not know about these attributes. 
So it will be good to add these default attributes at the time of product import.