### PR TITLE
Fix/default attributes

### DIFF
--- a/create_config.sh
+++ b/create_config.sh
@@ -5,5 +5,5 @@ cat > "config.js" << EOF
 exports.config = {
   client_id: "${SPHERE_CLIENT_ID}",
   client_secret: "${SPHERE_CLIENT_SECRET}",
-  project_key: "${SPHERE_PROJECT_KEY}",
+  project_key: "${SPHERE_PROJECT_KEY}"
 }

--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -281,6 +281,8 @@ class ProductImport
     , {concurrency: 1}
 
   _ensureDefaultAttributesInProducts: (products, queriedEntries) =>
+    if queriedEntries
+      queriedEntries = _.compact(queriedEntries)
     Promise.map products, (product) =>
       if queriedEntries?.length > 0
         @logger.debug('Find matching product from server')

--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -121,7 +121,7 @@ class ProductImport
           debug 'Ensuring default attributes'
           @_ensureDefaultAttributesInProducts(productsToProcess, queriedEntries)
           .then () =>
-            Promise.resolve (queriedEntries)
+            Promise.resolve(queriedEntries)
         else
           Promise.resolve(queriedEntries)
       .then (queriedEntries) =>

--- a/test/ensure-default-attributes.spec.coffee
+++ b/test/ensure-default-attributes.spec.coffee
@@ -83,3 +83,32 @@ describe 'Ensure default attributes unit tests', ->
       expect(updatedProduct).toEqual(expectedProduct)
       done()
     .catch done
+
+  it ' :: should not overwrite existing attributes', (done) ->
+    inputVariant = {}
+    extendedVariantAttributes = _.deepClone(variantAttributes)
+    inputVariant.attributes = extendedVariantAttributes
+    inputProduct = {}
+    inputProduct.masterVariant = inputVariant
+    inputProduct.variants = [inputVariant]
+
+    serverVariant = {}
+    expectedAttributeValue = 'attributeValue11'
+    serverAttribute =
+      name: 'defaultAttribute1'
+      value: expectedAttributeValue
+    serverAttributes = [serverAttribute]
+
+    serverVariant.attributes = serverAttributes
+    serverProduct = {}
+    serverProduct.masterVariant = serverVariant
+    serverProduct.variants = [serverVariant]
+
+    @import.ensureDefaultAttributesInProduct(inputProduct, serverProduct)
+    .then (updatedProduct) =>
+      expectedMasterAttribute = @import._isAttributeExisting(serverAttribute, updatedProduct.masterVariant.attributes)
+      expect(expectedMasterAttribute.value).toBe(expectedAttributeValue)
+
+      expectedVariantAttribute = @import._isAttributeExisting(serverAttribute, updatedProduct.variants[0].attributes)
+      expect(expectedVariantAttribute.value).toBe(expectedAttributeValue)
+    .finally done

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -183,6 +183,8 @@ describe 'ProductImport unit tests', ->
 
     errorDir = path.join(__dirname, '../errors')
 
+    console.log('project key is ' + ClientConfig.config.project_key)
+
     Config =
       clientConfig: ClientConfig
       errorDir: errorDir

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -511,6 +511,7 @@ describe 'ProductImport unit tests', ->
       spyOn(@import, "_createOrUpdate").andCallFake -> Promise.settle([Promise.resolve({statusCode: 201}), Promise.resolve({statusCode: 200})])
       spyOn(@import, "_ensureProductTypesInMemory").andCallFake -> Promise.resolve()
       @import.ensureEnums = false
+      @import.defaultAttributesService = null
       @import._processBatches(sampleProducts)
       .then =>
         expect(@import._extractUniqueSkus).toHaveBeenCalled()

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -183,8 +183,6 @@ describe 'ProductImport unit tests', ->
 
     errorDir = path.join(__dirname, '../errors')
 
-    console.log('project key is ' + ClientConfig.config.project_key)
-
     Config =
       clientConfig: ClientConfig
       errorDir: errorDir

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -947,6 +947,13 @@ describe 'ProductImport unit tests', ->
 
       sampleInput.masterVariant.attributes.push sampleDefaultExistingAttr
 
+      sampleServerProduct1 = _.deepClone sampleInput
+      sampleServerProduct1.masterVariant.sku = '000'
+      sampleServerProduct1.variants = []
+
+      sampleServerProduct2 = _.deepClone sampleInput
+      sampleServerProduct2.variants = []
+
       expectedOutput = _.deepClone sampleNewProduct
       expectedOutput.masterVariant = _.deepClone sampleMasterVariant
       expectedOutput.variants = []
@@ -958,7 +965,7 @@ describe 'ProductImport unit tests', ->
       expectedOutput.variants[0].attributes = expectedOutput.variants[0].attributes.concat _.deepClone(sampleDefaultAttributes)
       expectedOutput.variants[1].attributes = expectedOutput.variants[1].attributes.concat _.deepClone(sampleDefaultAttributes)
 
-      @import._ensureDefaultAttributesInProducts([sampleInput])
+      @import._ensureDefaultAttributesInProducts([sampleInput], [sampleServerProduct1, sampleServerProduct2])
       .then ->
         expect(sampleInput).toEqual(expectedOutput)
         done()


### PR DESCRIPTION
Default attributes overwrite the server attributes, if the default attribute is not defined in the imported file. It should first load the product from the server and then compare it with the default attributes.