### PR TITLE
test(import): Add test for an import of a product without variants array

### DIFF
--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -478,7 +478,6 @@ class ProductImport
     else
       Promise.resolve(variant)
 
-
   _fetchAndResolveCustomReferencesByVariant: (variant) ->
     @_fetchAndResolveCustomAttributeReferences(variant)
     .then (variant) =>
@@ -488,10 +487,8 @@ class ProductImport
     Promise.map attributeValue, (referenceObject) =>
       @_resolveCustomReference(referenceObject)
 
-
   _isReferenceTypeAttribute: (attribute) ->
     _.has(attribute, 'type') and attribute.type.name is 'reference'
-
 
   _resolveCustomReference: (referenceObject) ->
     service = switch referenceObject.type.referenceTypeId
@@ -502,7 +499,6 @@ class ProductImport
     ref.id = referenceObject.value
     predicate = referenceObject._custom.predicate
     @_resolveReference service, refKey, ref, predicate
-
 
   _resolveProductCategories: (cats) ->
     new Promise (resolve, reject) =>

--- a/test/integration/product-import.spec.coffee
+++ b/test/integration/product-import.spec.coffee
@@ -187,7 +187,7 @@ describe 'Product Importer integration tests', ->
         done()
   , 30000
 
-  it 'should import product even when there are no variants are provided', (done) ->
+  it 'should import product even when there are no variants provided', (done) ->
     productDraft = createProduct()[0]
     productDraft.masterVariant.sku = 'uniqueSku'
     delete productDraft.variants


### PR DESCRIPTION
#### Summary
This PR fixes #92 

I was not able to reproduce this bug with integration test nor with https://github.com/sphereio/sphere-node-cli project where I tried to import JSON file containing a product with delete variants array so I pushed at least the test for it.

#### Todo

- Tests
    - [ ] Unit
    - [x] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
