### PR TITLE
fix(productImport): Fix max 500 update actions per update request error

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bluebird": "2.10.2",
+    "bluebird": "^3.0.0",
     "cuid": "^1.3.8",
     "debug": "2.2.0",
     "fs-extra": "0.22.1",
     "sphere-node-sdk": "^1.14.0",
-    "sphere-node-utils": "0.7.0",
+    "sphere-node-utils": "^0.9.1",
     "underscore": "1.8.3",
     "underscore-mixins": "0.1.4",
     "underscore.string": "3.2.2"

--- a/test/integration/test-helper.coffee
+++ b/test/integration/test-helper.coffee
@@ -15,7 +15,7 @@ unpublishProduct = (logger, client, product) ->
 
 deleteProduct = (logger, client, product) ->
   unpublishProduct(logger, client, product)
-  .then (response) =>
+  .then (response) ->
     client.products.byId(response.id).delete(response.version)
     .then (results) ->
       logger.debug "#{_.size results} deleted."


### PR DESCRIPTION
#### Summary
This PR fixes #83 - it splits update actions into smaller chunks (max 500 actions per one chunk) and send them to API one by one.

#### Todo

- Tests
    - [ ] Unit
    - [x] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
