### PR TITLE
refactor(productImport): Do not send an unnecessary request

### DIFF
--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -126,7 +126,7 @@ class ProductImport
           @_updateProductType(uniqueEnumUpdateActions)
       .then =>
         skus = @_extractUniqueSkus(productsToProcess)
-        @_getExistingProductsForSkus(skus)
+        if skus.length then @_getExistingProductsForSkus(skus) else []
       .then (queriedEntries) =>
         if @defaultAttributesService
           debug 'Ensuring default attributes'
@@ -164,16 +164,14 @@ class ProductImport
         @_getWhereQueryLimit()
       )
       Promise.map(skuChunks, (skus) =>
-        new Promise (resolve, reject) =>
-          predicate = @_createProductFetchBySkuQueryPredicate(skus)
-          @client.productProjections
-          .where(predicate)
-          .staged(true)
-          .all()
-          .fetch()
-          .then ({ body: { results } }) ->
-            resolve(results)
-          .catch (err) -> reject(err)
+        predicate = @_createProductFetchBySkuQueryPredicate(skus)
+        @client.productProjections
+        .where(predicate)
+        .staged(true)
+        .all()
+        .fetch()
+        .then (res) ->
+          res.body.results
       , { concurrency: 30 })
       .then (results) ->
         debug 'Fetched products: %j', results
@@ -210,11 +208,8 @@ class ProductImport
       when 200 then @_summary.updated++
 
   _createProductFetchBySkuQueryPredicate: (skus) ->
-    if skus.length is 0
-      'masterVariant(sku in ("")) or variants(sku in (""))'
-    else
-      skuString = "sku in (#{skus.map((val) -> JSON.stringify(val))})"
-      "masterVariant(#{skuString}) or variants(#{skuString})"
+    skuString = "sku in (#{skus.map((val) -> JSON.stringify(val))})"
+    "masterVariant(#{skuString}) or variants(#{skuString})"
 
   _extractUniqueSkus: (products) ->
     skus = []

--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -168,6 +168,7 @@ class ProductImport
         @client.productProjections
         .where(predicate)
         .staged(true)
+        .perPage(100)
         .all()
         .fetch()
         .then (res) ->

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -676,12 +676,8 @@ describe 'ProductImport unit tests', ->
       .finally -> done()
 
   describe '::_createProductFetchBySkuQueryPredicate', ->
-    it 'should return valid predicate if no skus are provided', ->
-      actual = @import._createProductFetchBySkuQueryPredicate []
-      expected = 'masterVariant(sku in ("")) or variants(sku in (""))'
-      expect(actual).toEqual(expected)
 
-    it 'should return valid predicate if no skus are provided', ->
+    it 'should return valid predicate if skus are provided', ->
       actual = @import._createProductFetchBySkuQueryPredicate ['sku1', 'sku2']
       expected = 'masterVariant(sku in ("sku1","sku2")) or variants(sku in ("sku1","sku2"))'
       expect(actual).toEqual(expected)


### PR DESCRIPTION
#### Summary
Resolves #106 

#### Description
This PR refactors how the existing products are fetched.
Also, I noticed that there is currently no way how to use this module for updating of an existing product which does not have a SKU. But I guess it is not in the scope of this issue.

#### Todo

- Tests
    - [ ] Unit
    - [x] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
