### PR TITLE
Restrict this tool to be used only with products which have SKU

### DIFF
--- a/readme/product-import.md
+++ b/readme/product-import.md
@@ -7,6 +7,8 @@ Accepts a list of products in a valid [JSON Schema](https://github.com/sphereio/
  * All the `categories` with the correct external ids used by the data to be imported
  * All `tax categories` be existing with the correct names to be used by the date to be imported
 
+Note that this tool can import only products which have at least one variant with SKU so it can check whether this product already exists on the API.
+
 ### Configuration
  The constructor requires the following:
   * logger instance

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -517,6 +517,16 @@ describe 'ProductImport unit tests', ->
       delete existingProducts[1]
       delete existingProducts[2]
 
+      # create product without SKU
+      sampleProducts.push
+        categories: [
+          {
+            typeId: 'category'
+            id: sampleProducts[0].categories[0].id
+          }
+        ]
+        masterVariant: {}
+
       spyOn(@import, "_extractUniqueSkus").andCallThrough()
       spyOn(@import, "_createProductFetchBySkuQueryPredicate").andCallThrough()
       spyOn(@import.client.productProjections,"fetch").andCallFake -> Promise.resolve({body: {results: existingProducts}})
@@ -529,7 +539,7 @@ describe 'ProductImport unit tests', ->
         expect(@import._extractUniqueSkus).toHaveBeenCalled()
         expect(@import._createProductFetchBySkuQueryPredicate).toHaveBeenCalled()
         expect(@import._summary).toEqual
-          emptySKU: 2
+          missingSKU: 1
           created: 1
           updated: 1
           failed: 0
@@ -547,8 +557,8 @@ describe 'ProductImport unit tests', ->
       spyOn(@import, "_fetchSameForAllAttributesOfProductType").andCallFake -> Promise.resolve([])
 
       @import.client.products = {}
-      @import.client.products.byId = () => @import.client.products
-      @import.client.products.update = () => Promise.resolve({ body: {} })
+      @import.client.products.byId = => @import.client.products
+      @import.client.products.update = -> Promise.resolve({ body: {} })
 
       @import._resolveReference = (service, refKey, ref, predicate) ->
         if(predicate.indexOf('throw exception') > 0)
@@ -558,7 +568,7 @@ describe 'ProductImport unit tests', ->
       @import.ensureEnums = false
       @import.defaultAttributesService = null
       @import._processBatches(sampleProducts)
-      .then =>
+      .then ->
         done()
       .catch (err) ->
         done(err)
@@ -590,8 +600,8 @@ describe 'ProductImport unit tests', ->
           }
         )
         skus = []
-        for i in [1..Math.round(Math.random()*1000)]
-          skus.push(randomString.generate(Math.round(Math.random()*100)))
+        for i in [1..Math.round(Math.random() * 1000)]
+          skus.push(randomString.generate(Math.round(Math.random() * 100)))
 
         chunks = @import.commonUtils._separateSkusChunksIntoSmallerChunks(
           skus,
@@ -610,7 +620,7 @@ describe 'ProductImport unit tests', ->
               expect(where.args.length).toEqual(1)
               actual = where.args[0]
               expected = @import._createProductFetchBySkuQueryPredicate(
-                chunks[index-1]
+                chunks[index - 1]
               )
               expect(actual).toEqual(expected)
           )
@@ -631,7 +641,7 @@ describe 'ProductImport unit tests', ->
       })
       skus = []
       for i in [1..10000]
-        skus.push(randomString.generate(Math.round(Math.random()*100)))
+        skus.push(randomString.generate(Math.round(Math.random() * 100)))
       chunks = @import.commonUtils._separateSkusChunksIntoSmallerChunks(
         skus,
         @import._getWhereQueryLimit()

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -539,7 +539,7 @@ describe 'ProductImport unit tests', ->
         expect(@import._extractUniqueSkus).toHaveBeenCalled()
         expect(@import._createProductFetchBySkuQueryPredicate).toHaveBeenCalled()
         expect(@import._summary).toEqual
-          missingSKU: 1
+          productsWithMissingSKU: 3
           created: 1
           updated: 1
           failed: 0


### PR DESCRIPTION
Resolves #111 

#### Summary
This PR filters out products which do not have SKUs so they won't be created even if they already exist on the API. It is because we are currently using only SKU to check for a product existence.

#### Todo

- Tests
    - [ ] Unit
    - [x] Integration
    - [ ] Acceptance
- [x] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
