### PR TITLE
chore(travis-CI): add node v8 to CI and remove v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - '4'
   - '6'
+  - '8'
 
 before_script:
   - ./create_config.sh

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "main": "./dist",
   "engines": {
-    "node": ">= 4.5"
+    "node": ">= 6.0.0"
   },
   "scripts": {
     "build": "grunt build",


### PR DESCRIPTION
#### Summary
Add node v8 to CI and remove v4

#### Description
Add of node v8 to CI and remove v4 in sphere-product-import
Change of engine from node  ">= 4.5" to  ">= 6.0.0" in package.json

Part of [this issue](https://github.com/commercetools/nodejs-tasks-board/issues/10)
