### PR TITLE
feat(price-import): Prices removal

### DIFF
--- a/lib/price-import.coffee
+++ b/lib/price-import.coffee
@@ -15,6 +15,7 @@ class PriceImport extends ProductImport
     @sync.config [{type: 'prices', group: 'white'}].concat(['base', 'references', 'attributes', 'images', 'variants', 'metaAttributes'].map (type) -> {type, group: 'black'})
     @repeater = new Repeater
     @preventRemoveActions = options.preventRemoveActions || false
+    @deleteOnEmpty = options.deleteOnEmpty || false
 
   _resetSummary: ->
     @_summary =
@@ -92,6 +93,21 @@ class PriceImport extends ProductImport
           typeId: 'channel'
       Promise.resolve price
 
+  _removeEmptyPrices: (actions) =>
+    # filter out new prices with empty centAmount
+    actions
+      .filter (action) ->
+        action.action isnt 'addPrice' or action.price.value.centAmount isnt ''
+
+      # remove prices which have empty centAmount in import file
+      .map (action) ->
+        if action.action is 'changePrice' and action.price.value.centAmount is ''
+          return {
+            action: 'removePrice'
+            priceId: action.priceId
+          }
+        action
+
   _createOrUpdate: (productsToProcess, existingProducts) ->
     debug 'Products to process: %j', {toProcess: productsToProcess, existing: existingProducts}
 
@@ -107,6 +123,10 @@ class PriceImport extends ProductImport
             payload = synced.getUpdatePayload()
             if @preventRemoveActions
               payload.actions = @_filterPriceActions(payload.actions)
+
+            if @deleteOnEmpty
+              payload.actions = @_removeEmptyPrices(payload.actions)
+
             if @publishingStrategy and @commonUtils.canBePublished(existingProduct, @publishingStrategy)
               payload.actions.push { action: 'publish' }
             updateTask(payload)

--- a/readme/price-importer.md
+++ b/readme/price-importer.md
@@ -10,6 +10,7 @@ Price Importer is used to import the prices for `existing` products of a project
   * errorDir -> error directory path (absolute), default: `../errors`
   * errorLimit -> maximum number of errors to log, default: 30. If set to 0, logs all errors
   * preventRemoveActions -> When `true` it filters out all remove actions. Defaults to `false`
+  * deleteOnEmpty -> When `true` it removes existing prices which have an empty string in `centAmount` in the import file. Defaults to `false`
   * publishingStrategy -> strategy for publishing the products with updates. Defaults to `false`
     * `always`: will always publish the products with updates.
     * `stagedAndPublishedOnly`: will publish the products only if the following conditions are met:
@@ -60,3 +61,20 @@ Price Importer is used to import the prices for `existing` products of a project
               ]
             }
           ]
+
+### Sample Input for removing a specific price
+Will match and remove price where `country == 'DE'` and `currencyCode == 'EUR'` 
+
+      prices = [
+            {
+              sku: 'sku1'
+              prices: [
+                {
+                  country: 'DE'
+                  value:
+                    centAmount: ''
+                    currencyCode: 'EUR'
+                }
+              ]
+            }
+    


### PR DESCRIPTION
This PR adds a possibility to remove specific prices by setting an empty string to `centAmount` property. It also adds a `deleteOnEmpty` config variable which enables this behavior.

Resolves #123
- Tests
    - [x] Unit
    - [x] Integration
    - [ ] Acceptance
- [x] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
