### PR TITLE
feat(product-import): Set product state when not specified

### DIFF
--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -653,6 +653,7 @@ class ProductImport
     else
       request = service.where(predicate)
       fetch = request.fetch()
+      # Prevent subsequent requests for this state before CTP has returned the first one has from triggering unnecessary calls to CTP.
       @_cache[refKey][predicate] = fetch
       fetch.then (result) =>
         @_processCompletedStateRequest(refKey, predicate, result, resolve, reject)

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -18,6 +18,11 @@ sampleTaxCategory = require '../samples/sample-tax-category.json'
 
 frozenTimeStamp = new Date().getTime()
 
+newState =
+  key: "New"
+  type: "ProductState"
+  initial: true
+
 TEST_TIMEOUT = 15000
 
 ensureResource = (service, predicate, sampleData) ->
@@ -65,6 +70,7 @@ describe 'Product import integration tests', ->
     .then => ensureResource(@client.categories, 'name(en="Snowboard equipment")', sampleCategory)
     .then => ensureResource(@client.taxCategories, 'name="Standard tax category"', sampleTaxCategory)
     .then => ensureResource(@client.types, "key=\"#{sampleType.key}\"", sampleType)
+    .then => ensureResource(@client.states, 'key="New"', newState)
     .then ->
       done()
     .catch (err) -> done(_.prettify err)

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -18,6 +18,8 @@ sampleTaxCategory = require '../samples/sample-tax-category.json'
 
 frozenTimeStamp = new Date().getTime()
 
+TEST_TIMEOUT = 15000
+
 ensureResource = (service, predicate, sampleData) ->
   debug 'Ensuring existence for: %s', predicate
   service.where(predicate).fetch()
@@ -66,14 +68,14 @@ describe 'Product import integration tests', ->
     .then ->
       done()
     .catch (err) -> done(_.prettify err)
-  , 10000 # 10sec
+  , TEST_TIMEOUT
 
   afterEach (done) ->
     @logger.info 'About to cleanup...'
     deleteProducts(@logger, @client)
     .then -> done()
     .catch (err) -> done(_.prettify err)
-  , 10000 # 10sec
+  , TEST_TIMEOUT
 
 
   it 'should import two new products', (done) ->
@@ -99,7 +101,7 @@ describe 'Product import integration tests', ->
       expect(fetchedProduct[0].slug).toEqual sampleImport.products[0].slug
       done()
     .catch done
-  , 10000
+  , TEST_TIMEOUT
 
   it 'should do nothing for empty products list', (done) ->
     @import._processBatches([])
@@ -108,7 +110,7 @@ describe 'Product import integration tests', ->
       expect(@import._summary.updated).toBe 0
       done()
     .catch done
-  , 10000
+  , TEST_TIMEOUT
 
   it 'should generate missing slug', (done) ->
     sampleImport = _.deepClone(sampleImportJson)
@@ -127,7 +129,7 @@ describe 'Product import integration tests', ->
       expect(fetchedProduct[0].slug.en).toBe "product-sync-test-product-1-#{frozenTimeStamp}"
       done()
     .catch done
-  , 10000
+  , TEST_TIMEOUT
 
   it 'should update existing product',  (done) ->
     sampleImport = _.deepClone(sampleImportJson)
@@ -165,7 +167,7 @@ describe 'Product import integration tests', ->
       expect(_.size result.body.results[0].variants).toBe 2
       done()
     .catch (err) -> done(_.prettify err.body)
-  , 10000
+  , TEST_TIMEOUT
 
   it 'should continue on error - duplicate slug', (done) ->
     # FIXME: looks like the API doesn't correctly validate for duplicate slugs
@@ -206,7 +208,7 @@ describe 'Product import integration tests', ->
         expect(@import._summary.created).toBe 1
         done()
       .catch done
-  , 10000
+  , TEST_TIMEOUT
 
   it 'should handle set type attributes correctly', (done) ->
     sampleImport = _.deepClone sampleImportJson
@@ -238,7 +240,7 @@ describe 'Product import integration tests', ->
       expect(result.body.results[0].masterVariant.attributes[0].value).toEqual setTextAttributeUpdated.value
       done()
     .catch done
-  , 10000
+  , TEST_TIMEOUT
 
   it 'should filter unknown attributes and import product without errors', (done) ->
     sampleImport = _.deepClone sampleImportJson
@@ -255,7 +257,8 @@ describe 'Product import integration tests', ->
       expect(@import._summary.unknownAttributeNames).toEqual ['unknownAttribute']
       done()
     .catch done
-  , 10000
+  , TEST_TIMEOUT
+
 
   it 'should update/create product with a new enum key', (done) ->
     @logger.info ':: should update/create product with a new enum key'

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -18,12 +18,12 @@ sampleTaxCategory = require '../samples/sample-tax-category.json'
 
 frozenTimeStamp = new Date().getTime()
 
+jasmine.getEnv().defaultTimeoutInterval = 30000
+
 newState =
   key: "New"
   type: "ProductState"
   initial: true
-
-TEST_TIMEOUT = 15000
 
 ensureResource = (service, predicate, sampleData) ->
   debug 'Ensuring existence for: %s', predicate
@@ -74,14 +74,12 @@ describe 'Product import integration tests', ->
     .then ->
       done()
     .catch (err) -> done(_.prettify err)
-  , TEST_TIMEOUT
 
   afterEach (done) ->
     @logger.info 'About to cleanup...'
     deleteProducts(@logger, @client)
     .then -> done()
     .catch (err) -> done(_.prettify err)
-  , TEST_TIMEOUT
 
 
   it 'should import two new products', (done) ->
@@ -107,7 +105,6 @@ describe 'Product import integration tests', ->
       expect(fetchedProduct[0].slug).toEqual sampleImport.products[0].slug
       done()
     .catch done
-  , TEST_TIMEOUT
 
   it 'should do nothing for empty products list', (done) ->
     @import._processBatches([])
@@ -116,7 +113,6 @@ describe 'Product import integration tests', ->
       expect(@import._summary.updated).toBe 0
       done()
     .catch done
-  , TEST_TIMEOUT
 
   it 'should generate missing slug', (done) ->
     sampleImport = _.deepClone(sampleImportJson)
@@ -135,7 +131,6 @@ describe 'Product import integration tests', ->
       expect(fetchedProduct[0].slug.en).toBe "product-sync-test-product-1-#{frozenTimeStamp}"
       done()
     .catch done
-  , TEST_TIMEOUT
 
   it 'should update existing product',  (done) ->
     sampleImport = _.deepClone(sampleImportJson)
@@ -173,7 +168,6 @@ describe 'Product import integration tests', ->
       expect(_.size result.body.results[0].variants).toBe 2
       done()
     .catch (err) -> done(_.prettify err.body)
-  , TEST_TIMEOUT
 
   it 'should continue on error - duplicate slug', (done) ->
     # FIXME: looks like the API doesn't correctly validate for duplicate slugs
@@ -214,7 +208,6 @@ describe 'Product import integration tests', ->
         expect(@import._summary.created).toBe 1
         done()
       .catch done
-  , TEST_TIMEOUT
 
   it 'should handle set type attributes correctly', (done) ->
     sampleImport = _.deepClone sampleImportJson
@@ -246,7 +239,6 @@ describe 'Product import integration tests', ->
       expect(result.body.results[0].masterVariant.attributes[0].value).toEqual setTextAttributeUpdated.value
       done()
     .catch done
-  , TEST_TIMEOUT
 
   it 'should filter unknown attributes and import product without errors', (done) ->
     sampleImport = _.deepClone sampleImportJson
@@ -263,7 +255,6 @@ describe 'Product import integration tests', ->
       expect(@import._summary.unknownAttributeNames).toEqual ['unknownAttribute']
       done()
     .catch done
-  , TEST_TIMEOUT
 
 
   it 'should update/create product with a new enum key', (done) ->

--- a/test/integration/product-import.spec.coffee
+++ b/test/integration/product-import.spec.coffee
@@ -128,7 +128,7 @@ newState =
   initial: true
 
 extantState =
-  key: "AlsoNewButIWantToCheckPopulatingWithANonDefaultState"
+  key: "AlsoNew" # Also new, but I want to check populating with a non-default state
   type: "ProductState"
   initial: true
 
@@ -181,7 +181,7 @@ describe 'Product Importer integration tests', ->
     .then (@productType) => ensureResource(@client.customerGroups, 'name="test-group"', sampleCustomerGroup)
     .then (@customerGroup) => ensureResource(@client.channels, 'key="test-channel"', sampleChannel)
     .then (@channel) => ensureResource(@client.states, 'key="New"', newState)
-    .then (@newState) => ensureResource(@client.states, 'key="AlsoNewButIWantToCheckPopulatingWithANonDefaultState"', extantState)
+    .then (@newState) => ensureResource(@client.states, 'key="AlsoNew"', extantState)
     .then (@extantState) => ensureResource(@client.states, 'key="Updated"', updatedState)
     .then (@updatedState) => ensureResource(@client.categories, 'externalId="test-category"', sampleCategory)
     .then (@category) =>
@@ -266,7 +266,7 @@ describe 'Product Importer integration tests', ->
         product = result.body.results[0]
 
         expect(product.state.id).toBe(@extantState.id)
-        expect(@import._cache["state"][product.state.id].key).toBe("AlsoNewButIWantToCheckPopulatingWithANonDefaultState")
+        expect(@import._cache["state"][product.state.id].key).toBe("AlsoNew")
         done()
 
   it 'should process updates for products where the update does not specify the state', (done) ->

--- a/test/integration/product-import.spec.coffee
+++ b/test/integration/product-import.spec.coffee
@@ -196,6 +196,9 @@ describe 'Product Importer integration tests', ->
       .then => cleanup(logger, @client.customerGroups, @customerGroup.id)
       .then => cleanup(logger, @client.channels, @channel.id)
       .then => cleanup(logger, @client.categories, @category.id)
+      .then => cleanup(logger, @client.states, @newState.id)
+      .then => cleanup(logger, @client.states, @extantState.id)
+      .then => cleanup(logger, @client.states, @updatedState.id)
       .then -> done()
       .catch (err) -> done(_.prettify err)
 


### PR DESCRIPTION
#### Summary

Set state to New for REWE Digital Marketplace partner products if state is not specified.  Fixes #125/[PIN-1887](https://jira.rewe-digital.com/browse/PIN-1887).*

#### Description
This work emerged out of the [addition of states](https://confluence.rewe-digital.com/pages/viewpage.action?pageId=364020405)* to the REWE Marketplace product model.  When new products are imported, the state is now set to `New` if it is not specified.

The pull request also includes a bit of refactoring.

∗ Sorry, open-source contributors, this link will not be accessible from outside of commercetools and REWE Digital.

- Tests
    - [X] Unit
    - [X] Integration
    - [ ] Acceptance
- [ ] Documentation
