### PR TITLE
Fix price import error - duplicate price scope

### DIFF
--- a/lib/price-import.coffee
+++ b/lib/price-import.coffee
@@ -15,19 +15,7 @@ class PriceImport extends ProductImport
   constructor: (@logger, options = {}) ->
     super @logger, options
 
-    disabledActionGroups = [
-      'base',
-      'meta',
-      'references',
-      'attributes',
-      'images',
-      'variants',
-      'categories',
-      'categoryOrderHints',
-    ]
     actionGroups = [{ type: 'prices', group: 'white' }]
-      .concat(disabledActionGroups.map (type) -> {type, group: 'black'})
-
     @syncProducts = createSyncProducts(actionGroups)
     @batchSize = options.batchSize or 30
     @repeater = new Repeater

--- a/lib/price-import.coffee
+++ b/lib/price-import.coffee
@@ -1,10 +1,13 @@
 debug = require('debug')('sphere-price-import')
+path = require 'path'
+fs = require 'fs-extra'
 _ = require 'underscore'
 _.mixin require 'underscore-mixins'
 Promise = require 'bluebird'
 slugify = require 'underscore.string/slugify'
 {SphereClient, ProductSync} = require 'sphere-node-sdk'
 {Repeater} = require 'sphere-node-utils'
+serializeError = require 'serialize-error'
 ProductImport = require './product-import'
 
 class PriceImport extends ProductImport

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "@commercetools/sync-actions": "^2.0.0",
     "bluebird": "^3.0.0",
     "commercetools-node-variant-reassignment": "1.1.0",
     "cuid": "^1.3.8",

--- a/test/integration/price-import.spec.coffee
+++ b/test/integration/price-import.spec.coffee
@@ -1,13 +1,14 @@
 debug = require('debug')('spec:it:sphere-product-import')
 _ = require 'underscore'
 _.mixin require 'underscore-mixins'
+Promise = require 'bluebird'
 {PriceImport} = require '../../lib'
 ClientConfig = require '../../config'
-Promise = require 'bluebird'
 { ExtendedLogger } = require 'sphere-node-utils'
 { deleteProducts } = require './test-helper'
 package_json = require '../../package.json'
-
+testProduct = require '../resources/product.json'
+testProductPrices = require '../resources/product-prices.json'
 
 sampleProductTypeForPrice =
   name: 'productTypeForPriceImport'
@@ -101,9 +102,7 @@ Config =
 describe 'Price Importer integration tests', ->
 
   beforeEach (done) ->
-
     @import = new PriceImport logger, Config
-
     @client = @import.client
 
     logger.info 'About to setup...'
@@ -214,7 +213,6 @@ describe 'Price Importer integration tests', ->
   , 30000
 
   it 'should update prices and publish the product', (done) ->
-
     @import.publishingStrategy = 'notStagedAndPublishedOnly'
 
     @client.products.byId(@product.id).update({
@@ -245,4 +243,31 @@ describe 'Price Importer integration tests', ->
       })
       .then ->
         done()
+  , 30000
+
+  it 'should remove missing prices', (done) ->
+    importer = new PriceImport logger, Config
+    importer.preventRemoveActions = true # disable price removing
+
+    _testProduct = _.deepClone(testProduct)
+    _testProduct.productType.id = @productType.id
+    logger.info 'importing test product'
+    ensureResource(@client.products, "key=\"#{_testProduct.key}\"", _testProduct)
+      .then () =>
+        logger.info 'importing prices'
+        importer.performStream [_.deepClone(testProductPrices)], _.noop
+      .then =>
+        @client.productProjections
+          .staged(true)
+          .where("key=\"#{_testProduct.key}\"")
+          .fetch()
+      .then (res) ->
+        product = res.body.results[0]
+        expect(product).toBeTruthy()
+        expect(product.masterVariant.prices.length).toBe(3)
+      .then ->
+        done()
+      .catch (err) ->
+        done(_.prettify err)
+
   , 30000

--- a/test/price-import.spec.coffee
+++ b/test/price-import.spec.coffee
@@ -258,7 +258,6 @@ describe 'PriceImport', ->
       .finally -> done()
 
     it 'should generate change actions', (done) ->
-
       existingProduct =
         version: 1
         masterVariant:
@@ -278,15 +277,14 @@ describe 'PriceImport', ->
 
       @import._createOrUpdate([ productsToProcess ], [ existingProduct ])
       .then =>
-
         actual = updateStub.update.mostRecentCall.args[0]
         expected =
           version: productsToProcess.version
           actions: [
             {
               action: "changePrice",
-              priceId: @priceDe.id
-              price: _.omit(changedPrice, 'id')
+              priceId: @priceDe.id,
+              price: changedPrice
             }
           ]
 

--- a/test/resources/product-prices.json
+++ b/test/resources/product-prices.json
@@ -1,0 +1,29 @@
+{
+  "prices": [
+    {
+      "country": "DE",
+      "value": {
+        "centAmount": 12900,
+        "currencyCode": "EUR"
+      },
+      "variant-sku": "sku12"
+    },
+    {
+      "country": "IT",
+      "value": {
+        "centAmount": 12900,
+        "currencyCode": "EUR"
+      },
+      "variant-sku": "sku12"
+    },
+    {
+      "country": "LT",
+      "value": {
+        "centAmount": 12900,
+        "currencyCode": "EUR"
+      },
+      "variant-sku": "sku12"
+    }
+  ],
+  "sku": "sku12"
+}

--- a/test/resources/product-prices.json
+++ b/test/resources/product-prices.json
@@ -3,26 +3,28 @@
     {
       "country": "DE",
       "value": {
-        "centAmount": 12900,
-        "currencyCode": "EUR"
-      },
-      "variant-sku": "sku12"
+        "centAmount": 1111,
+        "currencyCode": "EUR",
+        "type": "centPrecision"
+      }
     },
     {
       "country": "IT",
       "value": {
-        "centAmount": 12900,
-        "currencyCode": "EUR"
-      },
-      "variant-sku": "sku12"
+        "centAmount": 1111,
+        "currencyCode": "EUR",
+        "type": "centPrecision",
+        "fractionDigits": 2
+      }
     },
     {
       "country": "LT",
       "value": {
-        "centAmount": 12900,
-        "currencyCode": "EUR"
-      },
-      "variant-sku": "sku12"
+        "centAmount": 1111,
+        "currencyCode": "EUR",
+        "type": "centPrecision",
+        "fractionDigits": 2
+      }
     }
   ],
   "sku": "sku12"

--- a/test/resources/product.json
+++ b/test/resources/product.json
@@ -23,7 +23,7 @@
         "value": {
           "type": "centPrecision",
           "currencyCode": "EUR",
-          "centAmount": 12900,
+          "centAmount": 1111,
           "fractionDigits": 2
         },
         "country": "DE"
@@ -32,7 +32,7 @@
         "value": {
           "type": "centPrecision",
           "currencyCode": "EUR",
-          "centAmount": 12900,
+          "centAmount": 1111,
           "fractionDigits": 2
         },
         "country": "LT"
@@ -41,7 +41,7 @@
         "value": {
           "type": "centPrecision",
           "currencyCode": "EUR",
-          "centAmount": 12900,
+          "centAmount": 1111,
           "fractionDigits": 2
         },
         "country": "LV"
@@ -50,7 +50,7 @@
         "value": {
           "type": "centPrecision",
           "currencyCode": "EUR",
-          "centAmount": 12900,
+          "centAmount": 1111,
           "fractionDigits": 2
         },
         "country": "IT"

--- a/test/resources/product.json
+++ b/test/resources/product.json
@@ -1,0 +1,66 @@
+{
+  "productType": {
+    "typeId": "product-type",
+    "id": "productTypeId"
+  },
+  "name": {
+    "en": "testProduct"
+  },
+  "description": {
+    "en": "testProduct"
+  },
+  "categories": [],
+  "categoryOrderHints": {},
+  "slug": {
+    "en": "testProduct"
+  },
+  "masterVariant": {
+    "id": 1,
+    "sku": "sku12",
+    "key": "sku12",
+    "prices": [
+      {
+        "value": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 12900,
+          "fractionDigits": 2
+        },
+        "country": "DE"
+      },
+      {
+        "value": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 12900,
+          "fractionDigits": 2
+        },
+        "country": "LT"
+      },
+      {
+        "value": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 12900,
+          "fractionDigits": 2
+        },
+        "country": "LV"
+      },
+      {
+        "value": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 12900,
+          "fractionDigits": 2
+        },
+        "country": "IT"
+      }
+    ],
+    "images": [],
+    "attributes": [],
+    "assets": []
+  },
+  "variants": [],
+  "searchKeywords": {},
+  "key": "testProduct"
+}


### PR DESCRIPTION
#### Summary
Fixes #128 

#### Description
This PR changes how we generate update actions when syncing prices - old sync module generated `remove` and `add` actions for prices which changed its position in prices array.

New [sync module](https://github.com/commercetools/nodejs/tree/master/packages/sync-actions) matches prices based on their properties.

#### Todo

- Tests
    - [x] Unit
    - [x] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
