### PR TITLE
fix: only print logger warning of error limit once

### DIFF
--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -233,7 +233,8 @@ class ProductImport
   _errorLogger: (res, logger) =>
     if @_summary.failed < @errorLimit or @errorLimit is 0
       logger.error res, "Skipping product due to an error"
-    else
+    else if !@errorLimitHasBeenCommunicated
+      @errorLimitHasBeenCommunicated = true
       logger.warn "
         Error not logged as error limit of #{@errorLimit} has reached.
       "


### PR DESCRIPTION
#### Summary
PR makes sure we only print this warning once as it otherwise floods the terminal.

resolves #135