### PR TITLE
Filter out duplicate products when fetching multiple batches, add test for query limit

### DIFF
--- a/lib/common-utils.coffee
+++ b/lib/common-utils.coffee
@@ -24,16 +24,15 @@ class CommonUtils
   ###
   _separateSkusChunksIntoSmallerChunks: (skus, queryLimit) ->
     whereQuery = "
-      masterVariant(sku in ()) or variants(sku in ())
+      masterVariant(sku IN ()) or variants(sku IN ())
     "
     fixBytes = Buffer.byteLength(encodeURIComponent(whereQuery),'utf-8')
     availableSkuBytes = queryLimit - fixBytes
     getBytesOfChunk = (chunk) ->
+      chunk = chunk.map((sku) => JSON.stringify(sku))
       # use two sku lists since we have to query for masterVariant and variant
       # with the same list of skus
-      skuString = encodeURIComponent(
-        "\"#{chunk.join('","')}\"\"#{chunk.join('","')}\""
-      )
+      skuString = encodeURIComponent("#{chunk}\"\"#{chunk}")
       return Buffer.byteLength(skuString,'utf-8')
     # the skusChunk is now small enough to fit in a query
     # now we split the skus array in chunks of the size of the skusChunk

--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -217,7 +217,9 @@ class ProductImport
       , { concurrency: 30 })
       .then (results) ->
         debug 'Fetched products: %j', results
-        resolve(_.flatten(results))
+
+        uniqueProducts = _.uniq(_.flatten(results), (product) -> product.id)
+        resolve(uniqueProducts)
       .catch (err) -> reject(err)
 
   _errorLogger: (res, logger) =>


### PR DESCRIPTION
#### Summary
Fixes #5 

#### Description
This PR fixes a method for fetching of existing products which could potentially return one product multiple times if it was fetched in multiple requests.

It adds also a test for query limit which on API is now [set to 15kb](https://docs.commercetools.com/http-api#disallowed-requests). In the importer, we have a code which breaks SKUs to multiple groups so there are no requests exceeding this limit.

In fact, it now ensures that the maximum URI length is 8192 so even if we combine it with headers, it should not exceed this limit.

@butenkor @lojzatran - could you please check whether this issue still persists?
#### Todo

- Tests
    - [ ] Unit
    - [x] Integration
    - [ ] Acceptance
- [ ] Documentation
<!-- Two persons should review a PR, don't forget to assign them. -->
