### PR TITLE
chore(package.json): bump variant reassignment module to v1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sphere-product-import",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -145,7 +145,7 @@
     },
     "ansi-colors": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.2.0.tgz",
       "integrity": "sha1-csMd4qDZoszQysMMyYI+6y9kNLU=",
       "requires": {
         "ansi-bgblack": "^0.1.1",
@@ -422,7 +422,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -1079,7 +1079,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -1174,7 +1174,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1218,7 +1218,7 @@
     },
     "colors": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
@@ -1231,9 +1231,9 @@
       }
     },
     "commercetools-node-variant-reassignment": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/commercetools-node-variant-reassignment/-/commercetools-node-variant-reassignment-1.1.2.tgz",
-      "integrity": "sha512-F1j/AJ3W1h4zmo5cwuZfo9aY7D4lH+xr5AWUN0Ty4CH5fdmizrOFxS9lz1LbmN51WhkBFVa8svbzCzqN18klag==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/commercetools-node-variant-reassignment/-/commercetools-node-variant-reassignment-1.1.3.tgz",
+      "integrity": "sha512-ttgvkuYMcE230uoUJGZq18CC4j1YfWPWl/AkXdk3CqOGfVKZAFNQCjtqdFzaO3OYhuywYTY4jmUrTQJXEdjwrA==",
       "requires": {
         "babel-core": "^6.21.0",
         "babel-plugin-array-includes": "^2.0.3",
@@ -1306,9 +1306,9 @@
       }
     },
     "core-js": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.1.tgz",
-      "integrity": "sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg=="
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1327,7 +1327,7 @@
     },
     "csv-stringify": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/csv-stringify/-/csv-stringify-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-2.1.0.tgz",
       "integrity": "sha512-wEmZksjlGEZEP0Ai7eyCQuVd68CUqP1TmQ7ay4bchtxTY37tAm1DgM1xPj2L9isEylGEmvfFwA6RXwnqLzKfuA==",
       "requires": {
         "lodash.get": "~4.4.2"
@@ -1507,7 +1507,7 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
@@ -1753,7 +1753,7 @@
     },
     "git-config-path": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
       "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -1978,7 +1978,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -2482,7 +2482,7 @@
       "dependencies": {
         "mkdirp": {
           "version": "0.3.5",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
           "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
           "dev": true
         }
@@ -2591,7 +2591,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -2666,7 +2666,7 @@
     },
     "log-utils": {
       "version": "0.2.1",
-      "resolved": "http://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
       "integrity": "sha1-pMIXoN2aUFFdm5ICBgkas9TgMc8=",
       "requires": {
         "ansi-colors": "^0.2.0",
@@ -2761,7 +2761,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -2779,7 +2779,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -2878,9 +2878,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.0.tgz",
-      "integrity": "sha512-SG2qscLE3iM4C0CNzGrsAojJHSVHMS1J8NnvJ31P1lH8P0hGHOiafmniNJz6w6q7vuoDlV7RdySlJgtqkFEVtQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.1.tgz",
+      "integrity": "sha512-k1u2uemjIGsn25zmujKnotgniC/gxQ9sdegdezeDiKdkDW56THUMqlz3urndKCXJxA6yPzSZbXx/QCMe/pxqsA=="
     },
     "ncp": {
       "version": "2.0.0",
@@ -2965,31 +2965,31 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "npm": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.5.0.tgz",
-      "integrity": "sha512-SPq8zG2Kto+Xrq55E97O14Jla13PmQT5kSnvwBj88BmJZ5Nvw++OmlWfhjkB67pcgP5UEXljEtnGFKZtOgt6MQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.8.0.tgz",
+      "integrity": "sha512-xMH6V0OCSJ5ZET6yWPI3BmJSqMMCuVJSIcLx3LSH/SrratFSt6EDuCuGRFMQYty98Q1l6x/7vKmfURosoyWgrA==",
       "requires": {
-        "JSONStream": "^1.3.4",
+        "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
-        "aproba": "~1.2.0",
+        "aproba": "^2.0.0",
         "archy": "~1.0.0",
         "bin-links": "^1.1.2",
         "bluebird": "^3.5.3",
-        "byte-size": "^4.0.3",
-        "cacache": "^11.2.0",
+        "byte-size": "^5.0.1",
+        "cacache": "^11.3.2",
         "call-limit": "~1.1.0",
-        "chownr": "~1.0.1",
-        "ci-info": "^1.6.0",
+        "chownr": "^1.1.1",
+        "ci-info": "^2.0.0",
         "cli-columns": "^3.1.2",
-        "cli-table3": "^0.5.0",
+        "cli-table3": "^0.5.1",
         "cmd-shim": "~2.0.2",
         "columnify": "~1.5.4",
         "config-chain": "^1.1.12",
@@ -3013,11 +3013,16 @@
         "inherits": "~2.0.3",
         "ini": "^1.3.5",
         "init-package-json": "^1.10.3",
-        "is-cidr": "^2.0.6",
+        "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "^2.0.2",
-        "libnpmhook": "^4.0.1",
+        "libcipm": "^3.0.3",
+        "libnpm": "^2.0.1",
+        "libnpmaccess": "*",
+        "libnpmhook": "^5.0.2",
+        "libnpmorg": "*",
+        "libnpmsearch": "*",
+        "libnpmteam": "*",
         "libnpx": "^10.2.0",
         "lock-verify": "^2.0.2",
         "lockfile": "^1.0.4",
@@ -3032,47 +3037,46 @@
         "lodash.union": "~4.6.0",
         "lodash.uniq": "~4.5.0",
         "lodash.without": "~4.4.0",
-        "lru-cache": "^4.1.3",
+        "lru-cache": "^4.1.5",
         "meant": "~1.0.1",
         "mississippi": "^3.0.0",
         "mkdirp": "~0.5.1",
         "move-concurrently": "^1.0.1",
         "node-gyp": "^3.8.0",
         "nopt": "~4.0.1",
-        "normalize-package-data": "~2.4.0",
-        "npm-audit-report": "^1.3.1",
+        "normalize-package-data": "^2.5.0",
+        "npm-audit-report": "^1.3.2",
         "npm-cache-filename": "~1.0.2",
         "npm-install-checks": "~3.0.0",
         "npm-lifecycle": "^2.1.0",
         "npm-package-arg": "^6.1.0",
-        "npm-packlist": "^1.1.12",
-        "npm-pick-manifest": "^2.1.0",
-        "npm-profile": "^3.0.2",
-        "npm-registry-client": "^8.6.0",
-        "npm-registry-fetch": "^1.1.0",
+        "npm-packlist": "^1.3.0",
+        "npm-pick-manifest": "^2.2.3",
+        "npm-profile": "*",
+        "npm-registry-fetch": "^3.9.0",
         "npm-user-validate": "~1.0.0",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
         "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^8.1.6",
+        "pacote": "^9.4.1",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.1.0",
+        "query-string": "^6.2.0",
         "qw": "~1.0.1",
         "read": "~1.0.7",
         "read-cmd-shim": "~1.0.1",
         "read-installed": "~4.0.3",
         "read-package-json": "^2.0.13",
-        "read-package-tree": "^5.2.1",
-        "readable-stream": "^2.3.6",
+        "read-package-tree": "^5.2.2",
+        "readable-stream": "^3.1.1",
         "readdir-scoped-modules": "*",
         "request": "^2.88.0",
         "retry": "^0.12.0",
-        "rimraf": "~2.6.2",
+        "rimraf": "^2.6.3",
         "safe-buffer": "^5.1.2",
-        "semver": "^5.5.1",
+        "semver": "^5.6.0",
         "sha": "~2.0.1",
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
@@ -3084,7 +3088,7 @@
         "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
         "umask": "~1.1.0",
-        "unique-filename": "~1.1.0",
+        "unique-filename": "^1.1.1",
         "unpipe": "~1.0.0",
         "update-notifier": "^2.5.0",
         "uuid": "^3.3.2",
@@ -3092,11 +3096,11 @@
         "validate-npm-package-name": "~3.0.0",
         "which": "^1.3.1",
         "worker-farm": "^1.6.0",
-        "write-file-atomic": "^2.3.0"
+        "write-file-atomic": "^2.4.2"
       },
       "dependencies": {
         "JSONStream": {
-          "version": "1.3.4",
+          "version": "1.3.5",
           "bundled": true,
           "requires": {
             "jsonparse": "^1.2.0",
@@ -3158,7 +3162,7 @@
           "bundled": true
         },
         "aproba": {
-          "version": "1.2.0",
+          "version": "2.0.0",
           "bundled": true
         },
         "archy": {
@@ -3171,6 +3175,28 @@
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "asap": {
@@ -3259,10 +3285,6 @@
           "version": "1.0.0",
           "bundled": true
         },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true
-        },
         "builtins": {
           "version": "1.0.3",
           "bundled": true
@@ -3272,27 +3294,51 @@
           "bundled": true
         },
         "byte-size": {
-          "version": "4.0.3",
+          "version": "5.0.1",
           "bundled": true
         },
         "cacache": {
-          "version": "11.2.0",
+          "version": "11.3.2",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "chownr": "^1.0.1",
-            "figgy-pudding": "^3.1.0",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.3",
+            "bluebird": "^3.5.3",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.1.15",
+            "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "move-concurrently": "^1.0.1",
             "promise-inflight": "^1.0.1",
             "rimraf": "^2.6.2",
-            "ssri": "^6.0.0",
-            "unique-filename": "^1.1.0",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
+          },
+          "dependencies": {
+            "chownr": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "lru-cache": {
+              "version": "5.1.1",
+              "bundled": true,
+              "requires": {
+                "yallist": "^3.0.2"
+              }
+            },
+            "unique-filename": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "unique-slug": "^2.0.0"
+              }
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true
+            }
           }
         },
         "call-limit": {
@@ -3321,15 +3367,15 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true
         },
         "ci-info": {
-          "version": "1.6.0",
+          "version": "2.0.0",
           "bundled": true
         },
         "cidr-regex": {
-          "version": "2.0.9",
+          "version": "2.0.10",
           "bundled": true,
           "requires": {
             "ip-regex": "^2.1.0"
@@ -3348,7 +3394,7 @@
           }
         },
         "cli-table3": {
-          "version": "0.5.0",
+          "version": "0.5.1",
           "bundled": true,
           "requires": {
             "colors": "^1.1.2",
@@ -3410,7 +3456,7 @@
           "bundled": true
         },
         "colors": {
-          "version": "1.1.2",
+          "version": "1.3.3",
           "bundled": true,
           "optional": true
         },
@@ -3441,6 +3487,28 @@
             "inherits": "^2.0.3",
             "readable-stream": "^2.2.2",
             "typedarray": "^0.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "config-chain": {
@@ -3479,6 +3547,10 @@
             "run-queue": "^1.0.0"
           },
           "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            },
             "iferr": {
               "version": "0.1.5",
               "bundled": true
@@ -3603,6 +3675,28 @@
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0",
             "stream-shift": "^1.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "ecc-jsbn": {
@@ -3669,6 +3763,12 @@
             "p-finally": "^1.0.0",
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            }
           }
         },
         "extend": {
@@ -3708,6 +3808,28 @@
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.4"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "forever-agent": {
@@ -3729,6 +3851,28 @@
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "fs-minipass": {
@@ -3760,6 +3904,26 @@
             "iferr": {
               "version": "0.1.5",
               "bundled": true
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
             }
           }
         },
@@ -3791,6 +3955,10 @@
             "wide-align": "^1.1.0"
           },
           "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            },
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
@@ -3803,7 +3971,7 @@
           }
         },
         "genfun": {
-          "version": "4.0.1",
+          "version": "5.0.0",
           "bundled": true
         },
         "gentle-fs": {
@@ -3820,6 +3988,10 @@
             "slide": "^1.1.6"
           },
           "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            },
             "iferr": {
               "version": "0.1.5",
               "bundled": true
@@ -3831,8 +4003,11 @@
           "bundled": true
         },
         "get-stream": {
-          "version": "3.0.0",
-          "bundled": true
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
         },
         "getpass": {
           "version": "0.1.7",
@@ -3875,6 +4050,12 @@
             "timed-out": "^4.0.0",
             "unzip-response": "^2.0.1",
             "url-parse-lax": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            }
           }
         },
         "graceful-fs": {
@@ -4009,25 +4190,24 @@
           "version": "2.1.0",
           "bundled": true
         },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "builtin-modules": "^1.0.0"
-          }
-        },
         "is-ci": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
             "ci-info": "^1.0.0"
+          },
+          "dependencies": {
+            "ci-info": {
+              "version": "1.6.0",
+              "bundled": true
+            }
           }
         },
         "is-cidr": {
-          "version": "2.0.6",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "cidr-regex": "^2.0.8"
+            "cidr-regex": "^2.0.10"
           }
         },
         "is-fullwidth-code-point": {
@@ -4142,43 +4322,175 @@
           }
         },
         "libcipm": {
-          "version": "2.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.1",
+            "figgy-pudding": "^3.5.1",
             "find-npm-prefix": "^1.0.2",
             "graceful-fs": "^4.1.11",
+            "ini": "^1.3.5",
             "lock-verify": "^2.0.2",
             "mkdirp": "^0.5.1",
             "npm-lifecycle": "^2.0.3",
             "npm-logical-tree": "^1.2.1",
             "npm-package-arg": "^6.1.0",
-            "pacote": "^8.1.6",
-            "protoduck": "^5.0.0",
+            "pacote": "^9.1.0",
             "read-package-json": "^2.0.13",
             "rimraf": "^2.6.2",
             "worker-farm": "^1.6.0"
           }
         },
-        "libnpmhook": {
-          "version": "4.0.1",
+        "libnpm": {
+          "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "figgy-pudding": "^3.1.0",
-            "npm-registry-fetch": "^3.0.0"
+            "bin-links": "^1.1.2",
+            "bluebird": "^3.5.3",
+            "find-npm-prefix": "^1.0.2",
+            "libnpmaccess": "^3.0.1",
+            "libnpmconfig": "^1.2.1",
+            "libnpmhook": "^5.0.2",
+            "libnpmorg": "^1.0.0",
+            "libnpmpublish": "^1.1.0",
+            "libnpmsearch": "^2.0.0",
+            "libnpmteam": "^1.0.1",
+            "lock-verify": "^2.0.2",
+            "npm-lifecycle": "^2.1.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.1.0",
+            "npm-profile": "^4.0.1",
+            "npm-registry-fetch": "^3.8.0",
+            "npmlog": "^4.1.2",
+            "pacote": "^9.2.3",
+            "read-package-json": "^2.0.13",
+            "stringify-package": "^1.0.0"
+          }
+        },
+        "libnpmaccess": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "get-stream": "^4.0.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^3.8.0"
           },
           "dependencies": {
-            "npm-registry-fetch": {
-              "version": "3.1.1",
+            "aproba": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "libnpmconfig": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "find-up": "^3.0.0",
+            "ini": "^1.3.5"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "figgy-pudding": "^3.1.0",
-                "lru-cache": "^4.1.2",
-                "make-fetch-happen": "^4.0.0",
-                "npm-package-arg": "^6.0.0"
+                "locate-path": "^3.0.0"
               }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "libnpmhook": {
+          "version": "5.0.2",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^3.8.0"
+          }
+        },
+        "libnpmorg": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^3.8.0"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "libnpmpublish": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "lodash.clonedeep": "^4.5.0",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^3.8.0",
+            "semver": "^5.5.1",
+            "ssri": "^6.0.1"
+          }
+        },
+        "libnpmsearch": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^3.8.0"
+          }
+        },
+        "libnpmteam": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^3.8.0"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "2.0.0",
+              "bundled": true
             }
           }
         },
@@ -4283,7 +4595,7 @@
           "bundled": true
         },
         "lru-cache": {
-          "version": "4.1.3",
+          "version": "4.1.5",
           "bundled": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -4405,6 +4717,12 @@
             "mkdirp": "^0.5.1",
             "rimraf": "^2.5.4",
             "run-queue": "^1.0.3"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            }
           }
         },
         "ms": {
@@ -4473,17 +4791,26 @@
           }
         },
         "normalize-package-data": {
-          "version": "2.4.0",
+          "version": "2.5.0",
           "bundled": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
+            "resolve": "^1.10.0",
             "semver": "2 || 3 || 4 || 5",
             "validate-npm-package-license": "^3.0.1"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.10.0",
+              "bundled": true,
+              "requires": {
+                "path-parse": "^1.0.6"
+              }
+            }
           }
         },
         "npm-audit-report": {
-          "version": "1.3.1",
+          "version": "1.3.2",
           "bundled": true,
           "requires": {
             "cli-table3": "^0.5.0",
@@ -4491,7 +4818,7 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true
         },
         "npm-cache-filename": {
@@ -4534,7 +4861,7 @@
           }
         },
         "npm-packlist": {
-          "version": "1.1.12",
+          "version": "1.3.0",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -4542,157 +4869,33 @@
           }
         },
         "npm-pick-manifest": {
-          "version": "2.1.0",
+          "version": "2.2.3",
           "bundled": true,
           "requires": {
+            "figgy-pudding": "^3.5.1",
             "npm-package-arg": "^6.0.0",
             "semver": "^5.4.1"
           }
         },
         "npm-profile": {
-          "version": "3.0.2",
+          "version": "4.0.1",
           "bundled": true,
           "requires": {
             "aproba": "^1.1.2 || 2",
-            "make-fetch-happen": "^2.5.0 || 3 || 4"
-          }
-        },
-        "npm-registry-client": {
-          "version": "8.6.0",
-          "bundled": true,
-          "requires": {
-            "concat-stream": "^1.5.2",
-            "graceful-fs": "^4.1.6",
-            "normalize-package-data": "~1.0.1 || ^2.0.0",
-            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-            "npmlog": "2 || ^3.1.0 || ^4.0.0",
-            "once": "^1.3.3",
-            "request": "^2.74.0",
-            "retry": "^0.10.0",
-            "safe-buffer": "^5.1.1",
-            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-            "slide": "^1.1.3",
-            "ssri": "^5.2.4"
-          },
-          "dependencies": {
-            "retry": {
-              "version": "0.10.1",
-              "bundled": true
-            },
-            "ssri": {
-              "version": "5.3.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "^5.1.1"
-              }
-            }
+            "figgy-pudding": "^3.4.1",
+            "npm-registry-fetch": "^3.8.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "1.1.0",
+          "version": "3.9.0",
           "bundled": true,
           "requires": {
+            "JSONStream": "^1.3.4",
             "bluebird": "^3.5.1",
-            "figgy-pudding": "^2.0.1",
-            "lru-cache": "^4.1.2",
-            "make-fetch-happen": "^3.0.0",
-            "npm-package-arg": "^6.0.0",
-            "safe-buffer": "^5.1.1"
-          },
-          "dependencies": {
-            "cacache": {
-              "version": "10.0.4",
-              "bundled": true,
-              "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
-              },
-              "dependencies": {
-                "mississippi": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "concat-stream": "^1.5.0",
-                    "duplexify": "^3.4.2",
-                    "end-of-stream": "^1.1.0",
-                    "flush-write-stream": "^1.0.0",
-                    "from2": "^2.1.0",
-                    "parallel-transform": "^1.1.0",
-                    "pump": "^2.0.1",
-                    "pumpify": "^1.3.3",
-                    "stream-each": "^1.1.0",
-                    "through2": "^2.0.0"
-                  }
-                }
-              }
-            },
-            "figgy-pudding": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "make-fetch-happen": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^10.0.4",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.0",
-                "lru-cache": "^4.1.2",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.2.4"
-              }
-            },
-            "pump": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            },
-            "smart-buffer": {
-              "version": "1.1.15",
-              "bundled": true
-            },
-            "socks": {
-              "version": "1.1.10",
-              "bundled": true,
-              "requires": {
-                "ip": "^1.1.4",
-                "smart-buffer": "^1.0.13"
-              }
-            },
-            "socks-proxy-agent": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "agent-base": "^4.1.0",
-                "socks": "^1.1.10"
-              }
-            },
-            "ssri": {
-              "version": "5.3.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "^5.1.1"
-              }
-            }
+            "figgy-pudding": "^3.4.1",
+            "lru-cache": "^4.1.3",
+            "make-fetch-happen": "^4.0.1",
+            "npm-package-arg": "^6.1.0"
           }
         },
         "npm-run-path": {
@@ -4797,34 +5000,57 @@
           }
         },
         "pacote": {
-          "version": "8.1.6",
+          "version": "9.4.1",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "cacache": "^11.0.2",
-            "get-stream": "^3.0.0",
-            "glob": "^7.1.2",
-            "lru-cache": "^4.1.3",
+            "bluebird": "^3.5.3",
+            "cacache": "^11.3.2",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.1.0",
+            "glob": "^7.1.3",
+            "lru-cache": "^5.1.1",
             "make-fetch-happen": "^4.0.1",
             "minimatch": "^3.0.4",
-            "minipass": "^2.3.3",
+            "minipass": "^2.3.5",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "normalize-package-data": "^2.4.0",
             "npm-package-arg": "^6.1.0",
-            "npm-packlist": "^1.1.10",
-            "npm-pick-manifest": "^2.1.0",
+            "npm-packlist": "^1.1.12",
+            "npm-pick-manifest": "^2.2.3",
+            "npm-registry-fetch": "^3.8.0",
             "osenv": "^0.1.5",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^1.1.1",
-            "protoduck": "^5.0.0",
+            "protoduck": "^5.0.1",
             "rimraf": "^2.6.2",
             "safe-buffer": "^5.1.2",
-            "semver": "^5.5.0",
-            "ssri": "^6.0.0",
-            "tar": "^4.4.3",
-            "unique-filename": "^1.1.0",
-            "which": "^1.3.0"
+            "semver": "^5.6.0",
+            "ssri": "^6.0.1",
+            "tar": "^4.4.8",
+            "unique-filename": "^1.1.1",
+            "which": "^1.3.1"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "5.1.1",
+              "bundled": true,
+              "requires": {
+                "yallist": "^3.0.2"
+              }
+            },
+            "minipass": {
+              "version": "2.3.5",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true
+            }
           }
         },
         "parallel-transform": {
@@ -4834,6 +5060,28 @@
             "cyclist": "~0.2.2",
             "inherits": "^2.0.3",
             "readable-stream": "^2.1.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "path-exists": {
@@ -4850,6 +5098,10 @@
         },
         "path-key": {
           "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
           "bundled": true
         },
         "performance-now": {
@@ -4898,10 +5150,10 @@
           "bundled": true
         },
         "protoduck": {
-          "version": "5.0.0",
+          "version": "5.0.1",
           "bundled": true,
           "requires": {
-            "genfun": "^4.0.1"
+            "genfun": "^5.0.0"
           }
         },
         "prr": {
@@ -4956,7 +5208,7 @@
           "bundled": true
         },
         "query-string": {
-          "version": "6.1.0",
+          "version": "6.2.0",
           "bundled": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
@@ -5022,7 +5274,7 @@
           }
         },
         "read-package-tree": {
-          "version": "5.2.1",
+          "version": "5.2.2",
           "bundled": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -5033,16 +5285,12 @@
           }
         },
         "readable-stream": {
-          "version": "2.3.6",
+          "version": "3.1.1",
           "bundled": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "readdir-scoped-modules": {
@@ -5113,10 +5361,10 @@
           "bundled": true
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "run-queue": {
@@ -5124,6 +5372,12 @@
           "bundled": true,
           "requires": {
             "aproba": "^1.1.1"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            }
           }
         },
         "safe-buffer": {
@@ -5135,7 +5389,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.5.1",
+          "version": "5.6.0",
           "bundled": true
         },
         "semver-diff": {
@@ -5155,6 +5409,28 @@
           "requires": {
             "graceful-fs": "^4.1.2",
             "readable-stream": "^2.0.2"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "shebang-command": {
@@ -5261,7 +5537,7 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.0",
+          "version": "3.0.3",
           "bundled": true
         },
         "sshpk": {
@@ -5300,6 +5576,28 @@
           "requires": {
             "readable-stream": "^2.1.5",
             "stream-shift": "^1.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "stream-shift": {
@@ -5336,7 +5634,7 @@
           }
         },
         "string_decoder": {
-          "version": "1.1.1",
+          "version": "1.2.0",
           "bundled": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -5420,6 +5718,28 @@
           "requires": {
             "readable-stream": "^2.1.5",
             "xtend": "~4.0.1"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "timed-out": {
@@ -5463,7 +5783,7 @@
           "bundled": true
         },
         "unique-filename": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true,
           "requires": {
             "unique-slug": "^2.0.0"
@@ -5624,7 +5944,7 @@
           "bundled": true
         },
         "write-file-atomic": {
-          "version": "2.3.0",
+          "version": "2.4.2",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -5707,9 +6027,9 @@
       "dev": true
     },
     "object-keys": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
     },
     "object-visit": {
       "version": "0.3.4",
@@ -5804,7 +6124,7 @@
     },
     "parse-git-config": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
       "integrity": "sha1-06mYQxcTL1c5hxK7pDjhKVkN34w=",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -5884,7 +6204,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -5920,7 +6240,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@commercetools/sync-actions": "^2.2.1",
     "await-mutex": "^1.0.2",
     "bluebird": "^3.0.0",
-    "commercetools-node-variant-reassignment": "^1.1.2",
+    "commercetools-node-variant-reassignment": "^1.1.3",
     "cuid": "^1.3.8",
     "debug": "^4.1.0",
     "fs-extra": "3.0.1",


### PR DESCRIPTION
This PR bumps variant reassignment module to [v1.1.3](https://github.com/commercetools/commercetools-node-variant-reassignment/releases/tag/v1.1.3) which fixes problems with an undefined `ctpProductToUpdate` variable.