### PR TITLE
feat(price-import):  remove empty properties

### DIFF
--- a/lib/price-import.coffee
+++ b/lib/price-import.coffee
@@ -21,6 +21,7 @@ class PriceImport extends ProductImport
     @repeater = new Repeater
     @preventRemoveActions = options.preventRemoveActions || false
     @deleteOnEmpty = options.deleteOnEmpty || false
+    @removeEmptyValues = options.removeEmptyValues || false
 
   _resetSummary: ->
     @_summary =
@@ -86,9 +87,9 @@ class PriceImport extends ProductImport
       @_preparePrice priceToProcess
     , {concurrency: 1}
 
-  _removeEmptyPriceFields: (price) =>
+  _removeEmptyPriceValues: (price) =>
     return _.pairs(price).reduce ((acc, [key,value]) ->
-      ## make sure we keep empty centAmounts for deletion (they are inside value)
+      ## make sure we keep empty centAmount for deletion (they are inside value)
       if value == "" || (key != 'value' && typeof value == 'object' && _.values(value).includes(""))
         value = null
       return Object.assign acc, if key and value then "#{key}": value else null
@@ -97,7 +98,8 @@ class PriceImport extends ProductImport
   _preparePrice: (priceToProcess) =>
     resolvedPrices = []
     Promise.map priceToProcess.prices, (price) =>
-      price = @_removeEmptyPriceFields(price)
+      if @removeEmptyValues
+        price = @_removeEmptyPriceValues(price)
       @_resolvePriceReferences(price)
       .then (resolved) ->
         resolvedPrices.push(resolved)

--- a/lib/price-import.coffee
+++ b/lib/price-import.coffee
@@ -87,9 +87,9 @@ class PriceImport extends ProductImport
     , {concurrency: 1}
 
   _removeEmptyPriceFields: (price) =>
-    return Object.entries(price).reduce ((acc, [key,value]) ->
+    return _.pairs(price).reduce ((acc, [key,value]) ->
       ## make sure we keep empty centAmounts for deletion (they are inside value)
-      if value == "" || (key != 'value' && typeof value == 'object' && Object.values(value).includes(""))
+      if value == "" || (key != 'value' && typeof value == 'object' && _.values(value).includes(""))
         value = null
       return Object.assign acc, if key and value then "#{key}": value else null
     ), {}

--- a/lib/price-import.coffee
+++ b/lib/price-import.coffee
@@ -86,9 +86,18 @@ class PriceImport extends ProductImport
       @_preparePrice priceToProcess
     , {concurrency: 1}
 
+  _removeEmptyPriceFields: (price) =>
+    return Object.entries(price).reduce ((acc, [key,value]) ->
+      ## make sure we keep empty centAmounts for deletion (they are inside value)
+      if value == "" || (key != 'value' && typeof value == 'object' && Object.values(value).includes(""))
+        value = null
+      return Object.assign acc, if key and value then "#{key}": value else null
+    ), {}
+
   _preparePrice: (priceToProcess) =>
     resolvedPrices = []
     Promise.map priceToProcess.prices, (price) =>
+      price = @_removeEmptyPriceFields(price)
       @_resolvePriceReferences(price)
       .then (resolved) ->
         resolvedPrices.push(resolved)

--- a/test/price-import.spec.coffee
+++ b/test/price-import.spec.coffee
@@ -143,20 +143,20 @@ describe 'PriceImport', ->
       expect(actual).toEqual(expected)
       done()
 
-  describe '_removeEmptyPriceFields', ->
+  describe '_removeEmptyPriceValues', ->
   
-    it 'should remove empty object fields', (done) ->
-      pricesWithEmptyFields = [
+    it 'should remove empty object params', (done) ->
+      pricesWithEmptyValues = [
         mockPrice({customerGroup: { typeId: "customer-group",id: "" } }),
         mockPrice({country: 'SE', currency: "SEK", amount: 2000}),
         mockPrice({currency: "SEK", amount: 2000}),
       ]
-      pricesWithEmptyFields[0].country = ''
-      pricesWithEmptyFields[0].value.centAmount = '' ## make sure we do not remove when centAmount is empty
-      pricesWithEmptyFields[2].country = ''
+      pricesWithEmptyValues[0].country = ''
+      pricesWithEmptyValues[0].value.centAmount = '' ## make sure we do not remove when centAmount is empty
+      pricesWithEmptyValues[2].country = ''
       
-      _removeEmptyPriceFields = @import._removeEmptyPriceFields
-      cleanedUpPrices = pricesWithEmptyFields.map (price) -> _removeEmptyPriceFields(price)
+      _removeEmptyPriceValues = @import._removeEmptyPriceValues
+      cleanedUpPrices = pricesWithEmptyValues.map (price) -> _removeEmptyPriceValues(price)
 
       expect(cleanedUpPrices[0]).toEqual(jasmine.objectContaining({
         value: { currencyCode: 'EUR', centAmount: '' }


### PR DESCRIPTION
#### Summary
PR introduces a feature to remove properties that got empty values.

#### Description
When we are passing in empty strings to the importer it would still include these, which then returned errors from the platform. One example is `country` which requires a correct `country code` string.
```
{ code: 'InvalidJsonInput',
  message: 'Request body does not contain valid JSON.',
  detailedErrorMessage:
    'actions -> price -> country: ISO 3166-1 country code expected.' 
}
```
The `_removeEmptyPriceValues` method will remove these and also make sure to keep the `value` property as we need an empty `centAmount` string there to remove prices [(ref)](https://github.com/sphereio/sphere-product-import/blob/d70f27521817455224ab3354244b442c42d3ec2f/lib/price-import.coffee#L125).

#### Todo

- Tests
    - [x] Unit

resolves #150
