### PR TITLE
chore(logger): Increase log depth level

### DIFF
--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -224,7 +224,7 @@ class ProductImport
 
   _errorLogger: (res, logger) =>
     if @_summary.failed < @errorLimit or @errorLimit is 0
-      logger.error(util.inspect(res, false, 3, true), "Skipping product due to an error")
+      logger.error(util.inspect(res, false, 10, true), "Skipping product due to an error")
     else if !@errorLimitHasBeenCommunicated
       @errorLimitHasBeenCommunicated = true
       logger.warn "

--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -224,7 +224,7 @@ class ProductImport
 
   _errorLogger: (res, logger) =>
     if @_summary.failed < @errorLimit or @errorLimit is 0
-      logger.error(util.inspect(res, false, 10, true), "Skipping product due to an error")
+      logger.error(util.inspect(res, false, 20, false), "Skipping product due to an error")
     else if !@errorLimitHasBeenCommunicated
       @errorLimitHasBeenCommunicated = true
       logger.warn "


### PR DESCRIPTION
#### Summary
This PR increases the log depth level in error logs
FIxes #144 

Logs before:
<img width="830" alt="Screenshot 2019-03-26 at 22 01 54" src="https://user-images.githubusercontent.com/1090382/55036854-c9b20a80-5013-11e9-99b4-787676594965.png">

Logs after:
<img width="836" alt="Screenshot 2019-03-26 at 22 07 16" src="https://user-images.githubusercontent.com/1090382/55036864-d0d91880-5013-11e9-83af-7dd727ee7a0c.png">
