### PR TITLE
Bump dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sphere-product-import",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1231,9 +1231,9 @@
       }
     },
     "commercetools-node-variant-reassignment": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/commercetools-node-variant-reassignment/-/commercetools-node-variant-reassignment-1.1.3.tgz",
-      "integrity": "sha512-ttgvkuYMcE230uoUJGZq18CC4j1YfWPWl/AkXdk3CqOGfVKZAFNQCjtqdFzaO3OYhuywYTY4jmUrTQJXEdjwrA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/commercetools-node-variant-reassignment/-/commercetools-node-variant-reassignment-1.1.4.tgz",
+      "integrity": "sha512-jHHJEf9l64lHgwI82tBTlLBZm4FxhNIkkgWWUUrnf9/fSgzBSPCs14+Gd0X5Vj2nLKn17E7chd84aiYI2OhZwg==",
       "requires": {
         "babel-core": "^6.21.0",
         "babel-plugin-array-includes": "^2.0.3",
@@ -2971,9 +2971,9 @@
       }
     },
     "npm": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.8.0.tgz",
-      "integrity": "sha512-xMH6V0OCSJ5ZET6yWPI3BmJSqMMCuVJSIcLx3LSH/SrratFSt6EDuCuGRFMQYty98Q1l6x/7vKmfURosoyWgrA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.9.0.tgz",
+      "integrity": "sha512-91V+zB5hDxO+Jyp2sUKS7juHlIM95dGQxTeQtmZI1nAI/7kjWXFipPrtwwKjhyKmV4GsS2LzJhrxRjGWsU9z/w==",
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -3024,7 +3024,7 @@
         "libnpmsearch": "*",
         "libnpmteam": "*",
         "libnpx": "^10.2.0",
-        "lock-verify": "^2.0.2",
+        "lock-verify": "^2.1.0",
         "lockfile": "^1.0.4",
         "lodash._baseindexof": "*",
         "lodash._baseuniq": "~4.6.0",
@@ -3050,7 +3050,7 @@
         "npm-install-checks": "~3.0.0",
         "npm-lifecycle": "^2.1.0",
         "npm-package-arg": "^6.1.0",
-        "npm-packlist": "^1.3.0",
+        "npm-packlist": "^1.4.1",
         "npm-pick-manifest": "^2.2.3",
         "npm-profile": "*",
         "npm-registry-fetch": "^3.9.0",
@@ -3059,7 +3059,7 @@
         "once": "~1.4.0",
         "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^9.4.1",
+        "pacote": "^9.5.0",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
@@ -3112,7 +3112,7 @@
           "bundled": true
         },
         "agent-base": {
-          "version": "4.2.0",
+          "version": "4.2.1",
           "bundled": true,
           "requires": {
             "es6-promisify": "^5.0.0"
@@ -3738,7 +3738,7 @@
           }
         },
         "es6-promise": {
-          "version": "4.2.4",
+          "version": "4.2.6",
           "bundled": true
         },
         "es6-promisify": {
@@ -4517,10 +4517,10 @@
           }
         },
         "lock-verify": {
-          "version": "2.0.2",
+          "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^5.1.2 || 6",
+            "npm-package-arg": "^6.1.0",
             "semver": "^5.4.1"
           }
         },
@@ -4861,7 +4861,7 @@
           }
         },
         "npm-packlist": {
-          "version": "1.3.0",
+          "version": "1.4.1",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -5000,7 +5000,7 @@
           }
         },
         "pacote": {
-          "version": "9.4.1",
+          "version": "9.5.0",
           "bundled": true,
           "requires": {
             "bluebird": "^3.5.3",
@@ -6027,9 +6027,9 @@
       "dev": true
     },
     "object-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@commercetools/sync-actions": "^2.2.1",
     "await-mutex": "^1.0.2",
     "bluebird": "^3.0.0",
-    "commercetools-node-variant-reassignment": "^1.1.3",
+    "commercetools-node-variant-reassignment": "^1.1.4",
     "cuid": "^1.3.8",
     "debug": "^4.1.0",
     "fs-extra": "3.0.1",


### PR DESCRIPTION
Use the newest version of variant reassignment dependency: https://github.com/commercetools/commercetools-node-variant-reassignment/releases/tag/v1.1.4