### PR TITLE
fix(product-import): add check for empty results from CTP

### DIFF
--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -719,6 +719,8 @@ class ProductImport
           else
             if _.size(result.body.results) > 1
               @logger.warn "Found more than 1 #{refKey} for #{ref.id}"
+            if _.isEmpty(result.body.results)
+              reject "Inconsistency between body.count and body.results.length. Result is #{JSON.stringify(result)}"
             @_cache[refKey][ref.id] = result.body.results[0]
             @_cache[refKey][result.body.results[0].id] = result.body.results[0]
             resolve(result.body.results[0].id)


### PR DESCRIPTION
#### Summary
In our projects, sometimes we get this the error message: `"Unhandled rejection TypeError: Cannot read property '0' of undefined.`

It could mean one of the 2 options:
1. platform delivers empty response
2. the sphere product import processes the response wrongly and didn’t add `result.body`

In this PR, I added more detailed logs so it's easier to investigate next time we got an error.
