### PR TITLE
feature(product-import): add before create and before update callbacks

### DIFF
--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -426,7 +426,7 @@ class ProductImport
         else
           @_prepareNewProduct(prodToProcess)
             .then (product) =>
-              return Promise.resolve(@beforeCreateCallback(product))
+             Promise.resolve(@beforeCreateCallback(product))
                 .then () -> product
             .then (product) =>
               @client.products.create(product)

--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -426,7 +426,7 @@ class ProductImport
         else
           @_prepareNewProduct(prodToProcess)
             .then (product) =>
-             Promise.resolve(@beforeCreateCallback(product))
+              Promise.resolve(@beforeCreateCallback(product))
                 .then () -> product
             .then (product) =>
               @client.products.create(product)

--- a/readme/product-import.md
+++ b/readme/product-import.md
@@ -39,9 +39,12 @@ Note that this tool can import only products which have at least one variant wit
         * the product that should be updated
         * the product that is being imported
       * an _array_ of update actions that should be ignored
-    * beforeCreateOrUpdateCallback: fn(prodToProcess, existingProducts)
+    * beforeCreateCallback: fn(prodToProcess)
       * prodToProcess are products from the external source that are ready to be synced
+    * beforeUpdateCallback: fn(existingProducts, prodToProcess, updateRequest)
       * existingProducts are products currently in CTP that have matching SKUs with prodToProcess
+      * prodToProcess are products from the external source that are ready to be synced
+      * updateRequest contains `updateRequest.version` with the current product version and `updateRequest.actions` with all update actions
     * variantReassignmentOptions
       * enabled: when set to `true`, [reassignment module](https://github.com/commercetools/commercetools-node-variant-reassignment) will run before product import.
 

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -443,7 +443,8 @@ describe 'ProductImport unit tests', ->
   describe '::_createOrUpdate', ->
 
     it 'should create a new product and update an existing product', (done) ->
-      beforeCreateOrUpdateCallbackCalled = false
+      beforeCreateCallbackCalled = false
+      beforeUpdateCallbackCalled = false
       samplePrice =
         country: 'DE'
         value:
@@ -503,14 +504,17 @@ describe 'ProductImport unit tests', ->
       spyOn(@import, "_fetchSameForAllAttributesOfProductType").andCallFake -> Promise.resolve([])
       spyOn(@import.client._rest, 'POST').andCallFake (endpoint, payload, callback) ->
         callback(null, {statusCode: 200}, {})
-      @import.beforeCreateOrUpdateCallback = (prodToProcess) ->
-        beforeCreateOrUpdateCallbackCalled = true
+      @import.beforeCreateCallback = () ->
+        beforeCreateCallbackCalled = true
+      @import.beforeUpdateCallback = () ->
+        beforeUpdateCallbackCalled = true
       @import._createOrUpdate([newProduct, updateProduct], existingProducts)
       .then =>
         expect(@import._prepareNewProduct).toHaveBeenCalled()
         expect(@import.client._rest.POST.calls[0].args[1]).toEqual newProduct
         expect(@import.client._rest.POST.calls[1].args[1]).toEqual expectedUpdateActions
-        expect(beforeCreateOrUpdateCallbackCalled).toEqual true
+        expect(beforeCreateCallbackCalled).toEqual true
+        expect(beforeUpdateCallbackCalled).toEqual true
         done()
       .catch done
 


### PR DESCRIPTION
#### Summary

After a consultation with the team I decided to make a change in the before create and update callback. Now it's split into 2 different callbacks and before update callback also receives list of update actions.

Fixes: https://github.com/sphereio/sphere-product-import/issues/165