### PR TITLE
bump sphere-node-sdk library from 3.0.0 to 3.1.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sphere-product-import",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8505,9 +8505,9 @@
       "dev": true
     },
     "sphere-node-sdk": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/sphere-node-sdk/-/sphere-node-sdk-3.0.1.tgz",
-      "integrity": "sha512-WZf/JDMHwAPFapoekqNXzkwM0ZQsoIpZGuKSKNr1gkktrQuDpZz/3dH1Ai206oltfEC2iaSaLpRn4CQO0pL7Ow==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/sphere-node-sdk/-/sphere-node-sdk-3.1.0.tgz",
+      "integrity": "sha512-/Q65Fc5mGO+LER6ZnzjA1oe6/1PADAizM2vZaaqRHZcVNAz7pfjeZLAyHElbpMF2Vzn6AcTccgfsUsTHaHJ7tQ==",
       "requires": {
         "debug": "4.1.1",
         "jsondiffpatch": "0.3.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sphere-product-import",
   "description": "Manage product data",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "homepage": "https://github.com/sphereio/sphere-product-import",
   "private": false,
   "author": {
@@ -46,7 +46,7 @@
     "debug": "^4.1.0",
     "fs-extra": "8.1.0",
     "serialize-error": "^5.0.0",
-    "sphere-node-sdk": "^3.0.0",
+    "sphere-node-sdk": "^3.1.0",
     "sphere-node-utils": "^2.0.0",
     "underscore": "1.9.1",
     "underscore-mixins": "0.1.4",


### PR DESCRIPTION
After changing the node-sdk we forgot to change the product-import, could we make a release also for the product-import ? 
